### PR TITLE
Add Changelog Generator Action to ospo-guide

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Changelog
+on:
+  release:
+    types:
+      - created
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Auto Generate changelog"
+        uses: heinrichreimer/action-github-changelog-generator@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
## Add Changelog Generator Action to ospo-guide

## Problem

We currently don't keep releases or a changelog on this project. 

## Solution

Auto-generate a changelog and start to use tags on this repository. 

## Result

A changelog will generate whenever a release is created based on the tags on this project. 

