### PR TITLE
GitHub Management Policy: Added new section on repository metadata

### DIFF
--- a/content/resources/github-management-policy.md
+++ b/content/resources/github-management-policy.md
@@ -175,7 +175,7 @@ Information required:
 
 ## Repository Metadata
 
-Every repository in DSACMS is required to have a code.json containing project metadata. For details on metadata requirements, creation, and maintenance, refer to [gov-codejson](https://github.com/DSACMS/gov-codejson).
+Every repository in DSACMS is required to have a code.json file containing project metadata. For details on metadata requirements, creation, and maintenance, refer to [gov-codejson](https://github.com/DSACMS/gov-codejson).
 
 ## Offboarding
 

--- a/content/resources/github-management-policy.md
+++ b/content/resources/github-management-policy.md
@@ -27,6 +27,8 @@ sticky_sidenav: true
 - [Request an outside collaborator to be added to a repo](#request-an-outside-collaborator-to-be-added-to-a-repo)
 - [Request a third-party integration to be added to the repo](#request-a-third-party-integration-to-be-added-to-the-repo)
 
+##### [Repository Metadata](#repository-metadata)
+
 ##### [Offboarding](#offboarding)
 
 - [Monthly audit of membership](#monthly-audit-of-membership)
@@ -171,7 +173,11 @@ Information required:
 - Project’s [Maturity Model Tier](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md)
 - Keys that will need to be created
 
-## GitHub Organization Management
+## Repository Metadata
+
+Every repository in DSACMS is required to have a code.json containing project metadata. For details on metadata requirements, creation, and maintenance, refer to [gov-codejson](https://github.com/DSACMS/gov-codejson).
+
+## Offboarding
 
 ### Monthly audit of membership
 


### PR DESCRIPTION
## GitHub Management Policy: Added new section on repository metadata

## Problem

We should add a new section on repository metadata since all repositories need to be in compliance with the SHARE IT Act.

## Solution

Added new section pointing to code.json docs.