### PR TITLE
Frontend: Use Feedback Banner 

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,28 @@
-{% comment %}
-This appears at the top of the page letting the user know it's an
-official government website
+{% comment %} This appears at the top of the page letting the user know this is a work in progress
 {% endcomment %}
 
-<div class="page-landing-page layout-demo ">
+<!-- Feedback Banner -->
+<div class="feedback-banner">
+  <div class="bg-primary-lightest text-ink text-center padding-1">
+    <div class="grid-container">
+      <p class="usa-banner__header-text">
+        Work in progress. We welcome questions and suggestions —
+        <a
+          class="usa-link usa-link--external"
+          rel="noreferrer"
+          target="_blank"
+          href="https://github.com/DSACMS/ospo-guide/issues/new"
+          >give us feedback.</a
+        >
+      </p>
+    </div>
+  </div>
+</div>
+
+{% comment %} This appears at the top of the page letting the user know it's an official government
+website {% endcomment %}
+
+<!-- <div class="page-landing-page layout-demo ">
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
   <div class="usa-banner">
     <div class="usa-accordion">
@@ -71,4 +90,4 @@ This is a temporary include to render redirects from the original de-risking gui
   {% if tags[0] == 'derisking' and redirect-url %}
     {% include 'derisking/redirect_url.html' %}
   {% endif %}
-</div>
+</div> -->

--- a/assets/_common/styles/_uswds-theme-settings.scss
+++ b/assets/_common/styles/_uswds-theme-settings.scss
@@ -18,7 +18,7 @@
   /*---------------------------------------------------------
   # Typography Settings
   ----------------------------------------------------------*/
-  $theme-font-type-sans: 'helvetica',
+  $theme-font-type-sans: 'public-sans',
   $theme-font-role-heading: 'sans',
   $theme-body-font-size: 'md',
   $theme-font-weight-semibold: 700,

--- a/assets/_common/styles/brand-colors.scss
+++ b/assets/_common/styles/brand-colors.scss
@@ -1,7 +1,7 @@
 /*----------------------------------------------------------
-# 18F colors
+# CMS colors
 -----------------------------------------------------------*/
-$brand-color-light: #B3EFFF;
+$brand-color-light: #e5f3fa;
 $brand-color-bright: #00CFFF;
 $brand-color-medium: #046B99;
 $brand-color-dark: #1C304A;


### PR DESCRIPTION
## Problem

Since this website is currently a work in progress and does not use a .gov domain at the moment, we would like to use the feedback banner from the metrics site.

## Solution

- Commented out `usa-banner`
- Added feedback banner with link to repository issues page
- Unrelated but also updated font to use `public-sans`

## Result

Feedback banner is shown as part of website header
<img width="1686" alt="Screenshot 2025-04-22 at 2 19 07 PM" src="https://github.com/user-attachments/assets/02177805-87a8-4f09-840d-8f3f79a601e2" />


## Test Plan
`npm install`
`npm run dev`