### PR TITLE
About: Add content to about page

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -24,21 +24,81 @@ subnav:
 
 ## History of Open Source at CMS
 
-<!-- TODO: Add content about history including  -->
+The [Centers for Medicare & Medicaid Services (CMS)](https://www.cms.gov) has been an active supporter of and has utilized the [Open Source Software (OSS)](https://www.cms.gov/tra/Application_Development/AD_0200_Open_Source_Introduction.htm) on several IT projects for its mission-critical programs. Since 2015, several CMS business units and offices have been actively releasing OSS as part of IT modernization projects.
+
+CMS has many active open source communities with hundreds of repositories across our many organizations (https://dsacms.github.io/metrics/organizations/). [Developer.cms.gov](https://www.developer.cms.gov) contains CMS' collection of APIs, datasets, frameworks, and style guides to develop applications that help people get the services and benefits they rely on
+- [Beneficiary FHIR Data (BFD) Server](https://github.com/CMSgov/beneficiary-fhir-data): BFD Server is an internal backend to Medicare beneficiaries' demographic, enrollment, and claims data in FHIR format.
+- [Beneficiary Claims Data API (BCDA)](https://bcda.cms.gov/): Enables Accountable Care Organizations (ACOs) to retrieve Medicare Part A/B/D claims data for beneficiaries.
+- [Data at the Point of Care API](https://dpc.cms.gov/): Enables making a patient's Medicare claims data available to healthcare providers for treatment purposes
+- [AB2D API](https://ab2d.cms.gov/): Provides Prescription Drug Sponsors with secure Medicare parts A and B claims data for their plan enrollees
+- [Blue Button 2.0](https://bluebutton.cms.gov/): Delivers Medicare Part A, B, and D data for over 60 million people with Medicare. Our most widely used and longest lived Open API projects.
+
+CMS has embraced Open Source development and is looking forward to releasing more software to the community to promote reuse. 
+
 
 ## CMS Open Source Strategy
 
-<!-- TODO: Add content -->
+Based on the goals outlined in the Federal Source Code Policy/OMB directive M-16-21, the CMS Open Source Policy was written in 2018 to promote transparency, collaboration, and reuse of government-funded software in support of healthcare solutions: https://github.com/CMSgov/cms-open-source-policy 
 
-https://www.cms.gov/tra/Application_Development/AD_0200_Open_Source_Introduction.htm#:~:text=The%20CMS%20Open%20Source%20Strategy,source%20in%20the%20federal%20government.
+The [CMS Technical Reference Architecture](https://dsacms.github.io/ospo-guide/about/tra/ ) also contains more information and guidance on using and releasing open source software.
 
 ## CMS Open Source Program Office
 
-<!-- TODO: Add content -->
+An open source program office (OSPO) serves as the center of competency for an organization's open source operations and structure. It is responsible for defining and implementing strategies and policies to guide these efforts. The function of the CMS OSPO is: 
+> “Establish and maintain guidance, policies, practices, and talent pipelines that advance equity, build trust, and amplify impact across CMS, HHS, and Federal Open Source Ecosystems by working and sharing openly.” 
 
-https://www.cms.gov/digital-service/open-source-program-office
+For more information, visit https://go.cms.gov/ospo.
+
 
 ### Conferences, Events, & Awards
 
-<!-- TODO: Add content and list of conferences + awards -->
-<!-- TODO: link to decks -->
+#### CMS OSPO in the News
+- [Health IT Leaders Receive Flywheel Awards from GovCIO Media & Research](https://govciomedia.com/health-it-leaders-receive-flywheel-awards-from-govcio-media-research/)
+- [Feds Prioritize Open-Source Software Security Initiatives](https://govciomedia.com/feds-prioritize-open-source-so-ftware-security-initiatives/)
+- [Nava Open-Source Summit: Modernizing Government with Code](https://ospo.gwu.edu/nava-open-source-summit-modernizing-government-code)
+- [Highlighting Patient and Expert Interviews from the 2024 Health Datapalooza](https://academyhealth.org/blog/2024-10/highlighting-patient-and-expert-interviews-2024-health-datapalooza)
+- [Establishing the First Open Source Program Office (OSPO) at a United States Federal Agency](https://insights.sei.cmu.edu/library/establishing-the-first-open-source-program-office-ospo-at-a-united-states-federal-agency/)
+- [Exploring Digital Transformation at the Centers for Medicare & Medicaid Services](https://www.businessofgovernment.org/blog/exploring-digital-transformation-centers-medicare-medicaid-services)
+- [PyCon May 2024](https://github.com/DSACMS/pycon-poster-2024/blob/main/repo-baselines.pdf)
+- Code for America Summit 2024
+- Open Source Summit North America (OSSNA) 2024 
+    * [Establishing a Repository Baseline](https://www.youtube.com/watch?v=v0aaVBicOjI)
+    * [Repository Cohorts](https://www.youtube.com/watch?v=FpVNSAj9eDg)
+- [Biden-⁠Harris Administration Releases End of Year Report on Open-Source Software Security Initiative](https://www.whitehouse.gov/wp-content/uploads/2024/01/Securing-the-Open-Source-Software-Ecosystem-OS3I-End-of-Year-Report-MASTERCOPY.pdf)
+- [Biden-⁠Harris Administration Releases End of Year Report on Open-Source Software Security and Memory Safe Programming Languages](https://www.whitehouse.gov/wp-content/uploads/2023/09/OS3I-RFI-Final-09232023.pdf)
+- [US Digital Response Case Study: How One Federal Agency Worked to Release Open Source Software Responsibly](https://www.usdigitalresponse.org/resources/cms-open-source-software)
+- [Managing Federal CHAOSS at CMS.gov - CHAOSScast](https://podcast.chaoss.community/81)
+- [Inside CMS’ Groundbreaking Open Source Program Office](https://www.youtube.com/watch?v=34LQnyB3ydQ)
+- [OSPOs in Highly Regulated Environments Panel Discussion @ Open Source Summit EU 2023](https://osseu2023.sched.com/event/1OGeo/panel-discussion-ospos-transition-paths-for-regulated-environments-ana-jimenez-santamaria-linux-foundation-maurice-hendriks-city-of-amsterdam-nico-rikken-alliander-clare-dillon-innersourcecommons-thomas-steenbergen-epam?iframe=no&w=100%&sidebar=yes&bg=no)
+- [Innersource Summit 2023: Innersource to Open Source Journey in Government](https://innersourcecommons.org/events/isc-2023/)
+- [Inside CMS’ Groundbreaking Open Source Program Office](https://www.youtube.com/watch?v=34LQnyB3ydQ)
+- [Repodiving into Open Source at CMS.gov](https://www.youtube.com/watch?v=AypgQch2Qpk)
+- TODOGroup OSPOlogy September 2023 Meeting
+- OSPOs for Good Summit 2023 @ United Nations Headquarters NYC
+- [Open Source and the Digital Service at CMS.gov - All Things Open 2022](https://www.youtube.com/watch?v=Q0EJIevZS0I)
+
+
+#### External Talks
+- [DSAC Lightning Talk @ Nava OSS Summit 2024](https://youtu.be/XGGcH8JnQns?si=Q3YiEFPxx5FyQxJ3)
+- [Open Source in Government: Raising the Floor and Ceiling as an Early-Career Software Engineer @ Grace Hopper Conference 2024](https://ghc.anitab.org/session-catalog/?search=open%20source#/session/1717218938114001YRXT)
+- [Open Source Summit: Advancing IT Solutions in Federal Health and Beyond](https://www.navapbc.com/events/open-source-summit-federal-health)
+- [https://atarc.org/event/open-source-summit/](https://atarc.org/event/open-source-summit/)
+- [Strengthening government engagement with the OSS community @ Code for America Summit 2024](https://events.bizzabo.com/codeforamerica/agenda/session/1339808)
+- [Repository Cohorts talk @ Open Source Summit North America 2024](https://youtu.be/FpVNSAj9eDg?si=HwfqpQwEktVj6MTs)
+- [Repository Cohorts: Poster Session @ PyCon May 2024](https://us.pycon.org/2024/speaker/profile/195/)
+- [Repository Cohorts: How OSPOs Can Programmatically Categorize All Their Repositories](https://www.youtube.com/watch?v=FpVNSAj9eDg)
+- [Establishing a Repository Baseline Talk @ Open Source Summit North America 2024](https://youtu.be/v0aaVBicOjI?si=WHE6nLg2BEe7NWY5)
+- [Open Source and the Digital Service at CMS.gov, All Things Open 2022 w/Melissa Eggelston](https://www.youtube.com/watch?v=Q0EJIevZS0I)
+    - Also presented at: [Linux Foundation Member Summit Deck](/decks/lfms-2022.pdf) hosted at https://static.sched.com/hosted_files/lfms22/0c/lfms-2022.pdf
+- [TODOGroup.org Monthly Meetup: OSPOs & Transition Paths for Highly Regulated Environments](https://www.youtube.com/watch?v=2QopYZbo3EQ)
+- [Open Source Summit EU 2023: OSPOs & Transition Paths for Regulated Environments](https://www.youtube.com/watch?v=kIMNgGfwvMA)
+
+#### Podcasts & Interviews
+- [Celebrating 100 episodes of CHAOSScast! (Podcast)](https://podcast.chaoss.community/100)
+- [Managing Federal CHAOSS at CMS.gov (Podcast)](https://podcast.chaoss.community/81)
+- [Inside CMS’s work to become more digital and open-source](https://fedscoop.com/radio/inside-cmss-work-to-become-more-digital-and-open-source-andrea-fletcher/)
+- [Securing the Future of Open Source Software](https://govciomedia.com/securing-the-future-of-open-source-software/)
+- [When 150M people depend on your code: Open source and government with Remy DeCausemaker](https://www.youtube.com/watch?v=kvM_DA9lk_Y)
+- [The power and responsibility of open source at CMS.](https://www.youtube.com/watch?v=I-8wy4H0Vy4)
+
+Link to our presentations: https://www.github.com/DSACMS/decks

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -101,4 +101,4 @@ For more information, visit https://go.cms.gov/ospo.
 - [When 150M people depend on your code: Open source and government with Remy DeCausemaker](https://www.youtube.com/watch?v=kvM_DA9lk_Y)
 - [The power and responsibility of open source at CMS.](https://www.youtube.com/watch?v=I-8wy4H0Vy4)
 
-Link to our presentations: https://www.github.com/DSACMS/decks
+Link to presentations: [https://www.github.com/DSACMS/decks](https://www.github.com/DSACMS/decks)


### PR DESCRIPTION
## About: Add content to about page

## Problem

About page is currently empty

## Solution

Included content reused from already published materials and presentations: 
- History of Open Source at CMS
- CMS Open Source Strategy, pointing to CMS Open Source Policy and TRA
- CMS OSPO
- Events, Conferences, Talks, Awards