### PR TITLE
Deployment: Add cache functionality

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,24 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
+      
+      - name: 11ty Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache
+          key: 11ty-cache
 
       - name: Build project
         run: npm run build
         env:
           BASEURL: /ospo-guide
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+      
+      - name: Save 11ty Cache
+        uses: actions/cache/save@v4
+        with:
+          path: .cache
+          key: 11ty-cache
 
       - name: Setup GitHub pages
         uses: actions/configure-pages@v5

--- a/_data/tools.js
+++ b/_data/tools.js
@@ -54,8 +54,7 @@ module.exports = async function () {
         }
       }
       catch (e) {
-        console.warn(`Failed to fetch ${repo}, skipping...`);
-        console.warn(e, 'error message');
+        console.warn(`No code.json file in ${repo}, skipping...`);
       }
     });
 
@@ -63,8 +62,6 @@ module.exports = async function () {
     console.log(`Unable to fetch repositories from ${orgName}`);
     console.log(e, 'error message');
   }
-
-  console.log(tools, "checking tools!");
 
   return tools;
 };


### PR DESCRIPTION
## Deployment: Add retrieve and save cache functionality

## Problem

To retrieve the tools data / call the GitHub API, `eleventy-fetch` uses a cache to restore data. Currently, deployment does not save and retrieve the cache.

## Solution

This PR adds cache functionality to the deploy GH Action job.

## Result

Tools cards in tools page should be shown now.

## Test Plan
Tested it on my local fork: https://natalialuzuriaga.github.io/ospo-guide/tools/