### PR TITLE
Add exemption criteria

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,7 @@ const { EleventyRenderPlugin } = require("@11ty/eleventy");
 const pluginRss = require('@11ty/eleventy-plugin-rss');
 const pluginNavigation = require('@11ty/eleventy-navigation');
 const markdownIt = require('markdown-it');
+const markdownItTaskLists = require('markdown-it-task-lists');
 const markdownItAttrs = require('markdown-it-attrs');
 const markdownItAnchor = require('markdown-it-anchor');
 const markdownItFootnote = require('markdown-it-footnote');
@@ -115,7 +116,7 @@ module.exports = function (config) {
   }).use(markdownItAnchor, {
     permalink: headingLinks,
     slugify: config.getFilter('slugify'),
-  }).use(markdownItAttrs).use(markdownItFootnote);
+  }).use(markdownItAttrs).use(markdownItFootnote).use(markdownItTaskLists);
   config.setLibrary('md', markdownLibrary);
 
   // Override Footnote opener

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -237,3 +237,22 @@ h2.heading-md {
     vertical-align: middle;
   }
 }
+
+/* Task checklists */
+.contains-task-list {
+  padding-left: 0;
+  margin-left: 0;
+
+  li {
+    list-style: none;
+    margin-left: 0;
+
+    &::marker {
+      content: none;
+    }
+
+    input[type="checkbox"] {
+      margin-right: 0.5em;
+    }
+  }
+}

--- a/content/outbound/exemption-criteria.md
+++ b/content/outbound/exemption-criteria.md
@@ -1,15 +1,15 @@
 ---
-title: Risk Acceptance and Excemption Criteria of Open Sourcing
-description: 'Guidance on risk acceptance and exception criteria for your repository'
-permalink: /outbound/exception-criteria/
+title: Risk Acceptance and Exemption Criteria of Open Sourcing
+description: 'Guidance on risk acceptance and exeption criteria for your repository'
+permalink: /outbound/exeption-criteria/
 layout: layouts/page
 section: outbound
 tags: ospo
 eleventyNavigation:
   parent: ospo-outbound
-  key: ospo-outbound-excemptioncriteria
+  key: ospo-outbound-exemptioncriteria
   order: 10
-  title: Risk Acceptance and Excemption Criteria of Open Sourcing
+  title: Risk Acceptance and Exeption Criteria of Open Sourcing
 sidenav: true
 sticky_sidenav: true
 ---

--- a/content/outbound/exemption-criteria.md
+++ b/content/outbound/exemption-criteria.md
@@ -1,0 +1,54 @@
+---
+title: Risk Acceptance and Excemption Criteria of Open Sourcing
+description: 'Guidance on risk acceptance and exception criteria for your repository'
+permalink: /outbound/exception-criteria/
+layout: layouts/page
+section: outbound
+tags: ospo
+eleventyNavigation:
+  parent: ospo-outbound
+  key: ospo-outbound-excemptioncriteria
+  order: 10
+  title: Risk Acceptance and Excemption Criteria of Open Sourcing
+sidenav: true
+sticky_sidenav: true
+---
+
+### [Sign off on risk acceptance of open-sourcing the software product](https://github.com/DSACMS/repo-scaffolder/blob/main/tier2/checklist.md#sign-off-on-risk-acceptance-of-open-sourcing-the-software-product)
+
+- **Date:** Add date
+- **Repository Name:** Add repo-name
+
+Before outbounding this repository, it’s important that the appropriate stakeholders review and acknowledge the risks and responsibilities associated with releasing the code to the public. This step ensures transparency and accountability while enabling informed decision making.
+
+#### Security and Privacy Verification
+- [ ] I acknowledge that this project does **NOT**:
+  - [ ] contain any PII/PHI, or create an identifiable risk to the privacy of an individual.
+  - [ ] interface with any CMS Internal Systems. 
+  - [ ] contain any keys or credentials to authenticate with CMS systems.
+
+#### National Security and Intelligence Verification
+- [ ] I acknowledge that this project is **NOT**:
+  - [ ] primarily for use in national security systems, as defined in Section 11103 of title 40, USC.
+  - [ ] created by an agency or part of an agency that is an element of the intelligence community, as defined in section 3(4) of the National Security Act of 1947.
+  - [ ] exempt under section 552(b) of title 5, USC (commonly known as the "Freedom of Information Act").
+
+#### Export and Regulatory Compliance
+- [ ] I acknowledge that this project is **NOT** prohibited under:
+  - [ ] Export Administration Regulations.
+  - [ ] International Traffic in Arms Regulations (ITAR).
+  - [ ] Regulations of the Transportation Security Administration related to the protection of sensitive information.
+  - [ ] Federal laws and regulations governing the sharing of classified information.
+
+If all boxes have been checked, please proceed to the **[Flipping the Switch](https://github.com/DSACMS/repo-scaffolder/blob/main/tier2/checklist.md#flipping-the-switch-making-the-repository-public)** section below this one, otherwise, this section must be filled out and approved by the indicated stakeholders before public release.
+
+After reviewing the materials prepared by the team that is working to open source the product, the business owner signs off on a risk acceptance for open-sourcing the software product.
+
+Requesting sign off from key people on this request.
+
+| Reviewer Organization            | Reviewer Names                                            | Reviewer’s Recommendation                                                               |
+| -------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Code Reviewer 's Reccommendation | CODE REVIEWER 1 <br> CODE REVIEWER 2 <br> CODE REVIEWER 3 | [Approved/Needs Approval] <br> [Approved/Needs Approval] <br> [Approved/Needs Approval] |
+| ISSO                             | ISSO REVIEWER                                             | [Approved/Needs Approval]                                                               |
+| ISG Technical Approval           | ISG REVIEWER                                              | [Approved/Needs Approval]                                                               |
+| Business Owner(s)                | BUSINESS OWNER 1 </n> BUSINESS OWNER 2                    | [Approved/Needs Approval] </n> [Approved/Needs Approval]                                |

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "esbuild": "^0.24.0",
         "esbuild-sass-plugin": "^3.3.1",
         "luxon": "^2.3.1",
-        "markdown-it-footnote": "^3.0.3"
+        "markdown-it-footnote": "^3.0.3",
+        "markdown-it-task-lists": "^2.1.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -2136,9 +2137,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001649",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
-      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
+      "version": "1.0.30001720",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
+      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
       "funding": [
         {
           "type": "opencollective",
@@ -2152,7 +2153,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -6494,6 +6496,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
       "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
     },
     "node_modules/matches-selector": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "esbuild": "^0.24.0",
     "esbuild-sass-plugin": "^3.3.1",
     "luxon": "^2.3.1",
-    "markdown-it-footnote": "^3.0.3"
+    "markdown-it-footnote": "^3.0.3",
+    "markdown-it-task-lists": "^2.1.1"
   },
   "mocha": {
     "timeout": 15000


### PR DESCRIPTION
## module-name: Exemption Criteria

## Problem
Risk acceptance and exemption criteria is missing from the OSPO Guide.

## Solution
Add a new page for Risk acceptance and exemption criteria.

## Result
A page for Risk acceptance and exemption criteria now exists in the OSPO Guide
- `markdown-it-task-lists` has been added to Eleventy config file to ensure proper checkboxes appear for markdown checklists
- `markdown-it-task-lists` installed in package.json
- SCSS added to ensure correct render in newer browsers

## Test Plan
- Test in browser