### PR TITLE
Add glossary to guide

### DIFF
--- a/content/resources/glossary.md
+++ b/content/resources/glossary.md
@@ -41,8 +41,11 @@ Data about data, or, data that describes other data. A key example would be the 
 ### Open Source Software (OSS)
 Software that can be accessed, used, modified, and shared by anyone. OSS is often distributed under licenses that comply with the definition of “Open Source” provided by the Open Source Initiative (https://opensource.org/osd) and/or that meet the definition of “Free Software” provided by the Free Software Foundation (https://www.gnu.org/philosophy/free-sw.html).
 
-### Publiccode.yml
+### [Publiccode.yml](https://yml.publiccode.tools/)
 A metadata file used by National and International Governmental Organizations to document and share public software developed or acquired by a Public Administration. 
+
+### Repository
+Also known as “repo” A repository is the most basic element of GitHub. They're easiest to imagine as a project's folder. A repository contains all of the project files (including documentation), and stores each file's revision history. Repositories can have multiple collaborators and can be either public or private.
 
 ### Repository Scaffolder
 Repository Scaffolder or repo-scaffolder for short is a suite of tools that helps projects create source code repositories that are compliant with Federal standards and guidelines and industry best practices.

--- a/content/resources/glossary.md
+++ b/content/resources/glossary.md
@@ -1,0 +1,60 @@
+---
+title: Glossary
+description: 'A glossary of definitions for frequently asked words and phrases'
+permalink: /resources/glossary/
+layout: layouts/page
+section: resources
+tags: ospo
+eleventyNavigation:
+  parent: ospo-resources
+  key: ospo-resources-glossary
+  order: 7
+  title: Glossary
+sidenav: true
+sticky_sidenav: true
+---
+
+### CI/CD
+Abbreviation for “Continuous Integration/Continuous deployment”. This is the practice of creating tools that automatically run that help with the development and maintenance of a software project whenever the source code changes. Integration usually takes the form of automatically running tests and/or checks on proposed changes to the source code. The continuous deployment side of things takes the form of automatically deploying, copying, or moving the code, whenever it passes key checks and approvals.
+
+### Code.json
+A metadata file used by U.S. federal agencies to document and share software projects. It provides a standardized format for describing open source and custom developed software.
+
+### Code.gov
+This platform is primarily intended to serve two distinct functions. First, it will act as an online collection of tools, guides, and best practices specifically designed to help agencies implement the framework presented in this policy. Second, it will serve as the primary discoverability portal for custom-developed code intended both for Government-wide reuse and for potential release as OSS. Code.gov is not intended to house the custom-developed code itself; rather, it is intended to serve as a tool for discovering custom-developed code that may be available for Government-wide reuse or as OSS, and to provide transparency into custom developed code that is developed using Federal funds. This discoverability portal will be publicly accessible and searchable via a variety of fields and constraints, such as the name of the project, its intended use, and the agency releasing the source code. Code.gov will be accessible at https://www.code.gov and will evolve over time as a community resource to facilitate the adoption of good custom source code development, sharing, and reuse practices.
+
+### Custom Developed code
+For the purposes of this policy, custom-developed code is code that is first produced in the performance of a Federal contract or is otherwise fully funded by the Federal Government. It includes code, or segregable portions of code, for which the Government could obtain unlimited rights under Federal Acquisition Regulations (FAR) Pt. 27 and relevant agency FAR Supplements. Custom-developed code also includes code developed by agency employees as part of their official duties. For the purposes of this policy, custom-developed code may include, but is not limited to, code written for software projects, modules, plugins, scripts, middleware, and APIs; it does not, however, include code that is truly exploratory or disposable in nature, such as that written by a developer experimenting with a new language or library.
+
+### Exemptions
+Conditions defined by the SHARE IT Act or related regulations that prevent a code repository from being publicly released due to legal, security, privacy, or export control restrictions. See: [EXEMPTIONS.md](https://github.com/DSACMS/gov-codejson/blob/main/docs/exemptions.md)
+
+### GitHub Actions
+GitHub Actions are Github’s method of supporting CI/CD natively on their source code hosting platform. They allow programs to be run on a hosted software project on GitHub in the cloud or elsewhere.
+
+### JSON
+JavaScript Object Notation - is a human-readable standard text-based format for representing structured data. It is based on JavaScript object syntax, and commonly used for transmitting data in web applications.
+
+### Metadata
+Data about data, or, data that describes other data. A key example would be the information that you see in the file explorer or Finder on a computer, such as date modified, file size, and file type. For the SHARE IT Act, metadata about the software, such as repository location, feedback mechanisms, and related ContractID(s), and contact information about the developers.
+
+### Open Source Software (OSS)
+Software that can be accessed, used, modified, and shared by anyone. OSS is often distributed under licenses that comply with the definition of “Open Source” provided by the Open Source Initiative (https://opensource.org/osd) and/or that meet the definition of “Free Software” provided by the Free Software Foundation (https://www.gnu.org/philosophy/free-sw.html).
+
+### Publiccode.yml
+A metadata file used by National and International Governmental Organizations to document and share public software developed or acquired by a Public Administration. 
+
+### Repository Scaffolder
+Repository Scaffolder or repo-scaffolder for short is a suite of tools that helps projects create source code repositories that are compliant with Federal standards and guidelines and industry best practices.
+
+### Schema
+The structure of how data is organized. This can be the structure of anything as big as a database to something as small as a file. For SHARE IT purposes, schema mostly describes the layout and fields of a code.json file.
+
+### Software
+Refers to (i) computer programs that comprise a series of instructions, rules, routines, or statements, regardless of the media in which recorded, that allow or cause a computer to perform a specific operation or series of operations; and (ii) recorded information comprising source code listings, design details, algorithms, processes, flow charts, formulas, and related material that would enable the computer program to be produced, created, or compiled.
+
+### Software reuse
+The practice of using existing software components, modules, or code to build new applications, rather than writing everything from scratch.
+ 
+### Source code
+Computer commands written in a computer programming language that is meant to be read by people. Generally, source code is a higher level representation of computer commands as they are written by people and, therefore, must be assembled or compiled before a computer can execute the code as a program.


### PR DESCRIPTION
## Problem
OSPO Guide is missing a glossary

## Solution
Add a glossary within resources

## Result
First glossary definitions

## Test Plan
Test in browser