### PR TITLE
Add package guide directory

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -108,6 +108,13 @@ module.exports = function (config) {
     return filterTagList([...tagSet]);
   });
 
+  // Add guides as collections
+  config.addCollection('packagingGuides', function (collectionApi) {
+    return collectionApi
+      .getFilteredByGlob('content/resources/packaging/*.md')
+      .filter(item => !item.inputPath.endsWith('index.md'));
+  });
+
   // Customize Markdown library and settings
   let markdownLibrary = markdownIt({
     html: true,

--- a/_includes/home/homepage-section-include.html
+++ b/_includes/home/homepage-section-include.html
@@ -1,10 +1,11 @@
 <ul class="usa-list">
     {% for section_page in collections.ospo %}
-    {% if section_page.data.section == section_slug %}
-      <li>
-        <a href="{{ section_page.data.permalink | url }}" class="usa-link">{{ section_page.data.eleventyNavigation.title }}</a>
-      </li>
+    {% assign main-level-key = section_page.data.tags | append: "-" | append : section_slug %}
+    {% if section_page.data.section == section_slug and section_page.data.eleventyNavigation.parent == main-level-key %}
+    <li>
+        <a href="{{ section_page.data.permalink | url }}"
+            class="usa-link">{{ section_page.data.eleventyNavigation.title }}</a>
+    </li>
     {% endif %}
     {% endfor %}
-    </ul>
-    
+</ul>

--- a/content/resources/packaging/exporting-python-projects.md
+++ b/content/resources/packaging/exporting-python-projects.md
@@ -1,14 +1,14 @@
 ---
 title: Packaging Python Projects
 description: 'Guidelines for publishing python projects as packages'
-permalink: /resources/packaging/
+permalink: /resources/packaging/exporting-python-projects/
 layout: layouts/page
 section: resources
 tags: ospo
 eleventyNavigation:
-  parent: ospo-resources
-  key: ospo-resources-packaging
-  order: 3
+  parent: ospo-resources-packaging
+  key: ospo-resources-packaging-exporting
+  order: 1
   title: Packaging Python Projects
 sidenav: true
 sticky_sidenav: true

--- a/content/resources/packaging/gitHub-repo-template-guide.md
+++ b/content/resources/packaging/gitHub-repo-template-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Creating GitHub Repo Templates
 description: 'Guidelines for publishing JavaScript projects as packages'
-permalink: /resources/packaging/gitHub-repo-template-guide/
+permalink: /resources/packaging/github-repo-template-guide/
 layout: layouts/page
 section: resources
 tags: ospo

--- a/content/resources/packaging/gitHub-repo-template-guide.md
+++ b/content/resources/packaging/gitHub-repo-template-guide.md
@@ -1,0 +1,133 @@
+---
+title: Creating GitHub Repo Templates
+description: 'Guidelines for publishing JavaScript projects as packages'
+permalink: /resources/packaging/gitHub-repo-template-guide/
+layout: layouts/page
+section: resources
+tags: ospo
+eleventyNavigation:
+  parent: ospo-resources-packaging
+  key: ospo-resources-packaging-exporting
+  order: 2
+  title: Creating GitHub Repo Templates
+sidenav: true
+sticky_sidenav: true
+---
+
+### **Phase 1: Initial Setup**
+
+#### **Step 1: Fork and Clone the Repository**
+
+1\. Go to the repository and fork it  
+2\. Clone fork locally, git clone \`repo-name\` \`name-of-template\`  
+3\. cd \`name-of-template\`  
+4\. Set up remotes:
+```shell
+git remote add upstream `name-of-template`  
+git remote -v  # Verify remotes are set up correctly
+```
+
+#### **Step 2: Create Frontend-Only Branch**
+
+*  Create a new branch for frontend template
+```shell  
+git checkout -b frontend-template-v1
+```
+
+* Remove non-frontend files (adjust paths based on actual structure)  
+```shell
+rm  -rf backend  # If backend folder exists  
+rm -rf docs/scripts  # Backend-specific scripts  
+rm -rf .github/workflows/deploy.yml  # Backend deployment workflows
+```
+
+* Keep only frontend-related files:  
+  * app/  
+  * .github/workflows/   
+  * Root files like .gitignore, [README.md](http://README.md)
+
+#### **Step 3: Clean Up Frontend Directory Structure**
+
+* Navigate to your frontend directory
+```shell
+cd app/
+```
+* Verify current structure  
+```shell
+ls -la
+```
+* Expected structure after cleanup:
+
+```shell
+app/
+ ├── site/
+ ├── src/
+ ├── .eleventy.js
+ ├── package.json
+ ├── package-lock.json
+ ├── postcss.config.js
+ └── rollup.config.mjs
+```
+
+### 
+
+### **Phase 2: Template Preparation**
+
+#### **Step 4: Create Template Documentation**
+
+* Create files in your repository root:  
+  * FILE: README.md (This replaces the existing README)  
+* Install dependencies  
+* Start development server  
+* Open local server  
+* Match project structure
+
+## **Ensure Build Commands Work**
+```shell
+npm run start  #Development server with hot reload  
+npm run build  #Production build (outputs to dist/)  
+npm run prod  #Test production build locally  
+npm run lint  #Check code quality  
+npm run prettier  #Format code
+```
+
+## **Deployment**
+
+### **Build for Production**
+```shell
+* cd app/  
+* npm run build
+```
+
+### **Deploy**
+
+* **GitHub Pages:** Push to gh-pages branch
+
+### **Customization Checklist**
+
+- [ ] Update app/site/\_data/ with your data sources  
+- [ ] Modify app/site/index.liquid homepage  
+- [ ] Customize app/src/css/ styling  
+- [ ] Update app/.eleventy.js configuration if needed  
+- [ ] Test build: npm run build  
+- [ ] Update README.md for your project
+
+## **Troubleshooting**
+
+### **Common Issues**
+
+* **Build fails:** Check Node.js version (requires 16+)  
+* **Styles not loading:** Run npm run build:postcss  
+* **JS errors:** Check npm run build:rollup
+
+## **Verification Checklist**
+
+After deployment, verify:
+
+- [ ] Site loads at your URL  
+- [ ] All CSS styles are applied  
+- [ ] JavaScript functionality works  
+- [ ] Images load correctly  
+- [ ] Navigation works  
+- [ ] Mobile responsiveness  
+- [ ] Performance (run Lighthouse audit)

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -16,7 +16,7 @@ subnav:
   - text: Packaging Python Projects
     href: '/resources/packaging/exporting-python-projects'
   - text: Creating GitHub Repo Templates
-    href: '/resources/packaging/gitHub-repo-template-guide/'
+    href: '/resources/packaging/github-repo-template-guide/'
   - text: Packaging JavaScript Projects
     href: '/resources/packaging/npm-packaging-guidelines/'
 ---

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -12,6 +12,13 @@ eleventyNavigation:
   title: Packaging Guides
 sidenav: true
 sticky_sidenav: true
+subnav:
+  - text: Packaging Python Projects
+    href: '/resources/packaging/exporting-python-projects'
+  - text: Creating GitHub Repo Templates
+    href: '/resources/packaging/gitHub-repo-template-guide/'
+  - text: Packaging JavaScript Projects
+    href: '/resources/packaging/npm-packaging-guidelines/'
 ---
 
 ### Below are guides related to packaging and publishing projects:

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -14,7 +14,7 @@ sidenav: true
 sticky_sidenav: true
 subnav:
   - text: Packaging Python Projects
-    href: '/resources/packaging/exporting-python-projects'
+    href: '/resources/packaging/exporting-python-projects/'
   - text: Creating GitHub Repo Templates
     href: '/resources/packaging/github-repo-template-guide/'
   - text: Packaging JavaScript Projects

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -1,0 +1,35 @@
+---
+title: Packaging Guides
+description: 'Packaging Guides'
+permalink: /resources/packaging/
+layout: layouts/page
+section: resources
+tags: ospo
+eleventyNavigation:
+  parent: ospo-resources
+  key: ospo-resources-packaging
+  order: 3
+  title: Packaging Guides
+sidenav: true
+sticky_sidenav: true
+---
+
+### Below are guides related to packaging and publishing projects:
+
+<ul style="list-style: none; padding-left: 0;">
+{% for guide in collections.packagingGuides %}
+    <li>
+        <style>
+            #packaging-style:hover {
+                background-color: #dfe1e2;
+            }
+        </style>
+        <a href="{{ guide.url }}" id="packaging-style"
+          style="text-decoration: none; font-size: 1.2rem; font-weight: 600;
+          color: #046b99; padding: 1.5%"
+        >
+          {{ guide.data.title }}
+        </a>
+    </li>
+{% endfor %}
+</ul>

--- a/content/resources/packaging/npm-packaging-guidelines.md
+++ b/content/resources/packaging/npm-packaging-guidelines.md
@@ -1,0 +1,99 @@
+---
+title: Packaging JavaScript Projects
+description: 'Guidelines for publishing python projects as packages'
+permalink: /resources/packaging/npm-packaging-guidelines/
+layout: layouts/page
+section: resources
+tags: ospo
+hideFromResources: true
+eleventyNavigation:
+  parent: ospo-resources-packaging
+  key: ospo-resources-packaging-exporting
+  order: 3
+  title: Packaging JavaScript Projects
+sidenav: true
+sticky_sidenav: true
+---
+
+# NPM Packaging Guidelines
+
+## **Prerequisites**
+
+* Node.js and npm installed  
+* Basic knowledge of HTML, CSS, and JavaScript  
+* Your frontend library code ready
+
+## **Steps**
+
+#### Step 1: Prepare Your Project Structure
+
+* Create a new directory for the package:
+```shell
+mkdir my-frontend-lib  
+cd my-frontend-lib
+```
+
+* Set up the basic folder structure:
+```shell
+my-frontend-lib/
+├── src/
+│   ├── index.js
+│   ├── styles.css
+│   └── components/
+├── examples/
+├── package.json
+├── README.md
+└── .gitignore
+```
+
+#### Step 2: Initialize the Package
+
+* Run npm init and answer the prompts:
+```shell 
+npm init - y
+```
+
+#### Step 3: Configure package.json
+
+* Edit your **`package.json`** to include these essential fields
+
+#### Step 4: Create Your Library Entry Point
+
+* Create **`src/index.js`** as your main entry point
+
+#### Step 5: Add Your Styles
+
+* Create **`src/styles.css`**
+
+#### Step 6: Create Documentation
+
+* Write a comprehensive **`README.md`**
+
+#### Step 7: Create `.gitignore`
+
+#### Step 8: Test Locally
+
+* Before publishing, test your package locally
+
+#### Step 9: Publish to NPM
+
+* First, create an npm account at [npmjs.com](http://npmjs.com)  
+  * Follow instructions
+
+#### Step 10: Version Management
+
+* Commands for updates
+```shell  
+npm version patch   #For bug fixes  
+npm version minor  #For new features  
+npm version major  #For breaking changes  
+npm publish  #Then publish the update
+```
+
+## **Common Mistakes**
+
+* Don't include \`node\_modules\` in your package  
+* Don't publish sensitive information  
+* Always test before publishing  
+* Don't break existing APIs without major version bump  
+* Include all necessary files in the files array


### PR DESCRIPTION
## module-name: Add package guidance directory and guidance for NPM and Templates

## Problem
No packaging guidance exists for NPM packages or GitHub Templates. Currently, Python Packaging Guidance lives directly in resources.

## Solution
Create a Package Guidance directory and add Python Packaging Guidance to it. Create Guidance for NPM packages and GitHub Templates.

## Result
A directory for guidance now exists in resources. Guidance for NPM and Templates created and added to directory.

## Test Plan
Test in browser