### PR TITLE
Fix relative path

### DIFF
--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -14,11 +14,11 @@ sidenav: true
 sticky_sidenav: true
 subnav:
   - text: Packaging Python Projects
-    href: '/resources/packaging/exporting-python-projects/'
+    href: 'resources/packaging/exporting-python-projects/'
   - text: Creating GitHub Repo Templates
-    href: '/resources/packaging/github-repo-template-guide/'
+    href: 'resources/packaging/github-repo-template-guide/'
   - text: Packaging JavaScript Projects
-    href: '/resources/packaging/npm-packaging-guidelines/'
+    href: 'resources/packaging/npm-packaging-guidelines/'
 ---
 
 ### Below are guides related to packaging and publishing projects:
@@ -28,7 +28,7 @@ subnav:
     <li>
         <style>
             #packaging-style:hover {
-                background-color: #dfe1e2;
+                background-color: #f1f1f1;
             }
         </style>
         <a href="{{ guide.url }}" id="packaging-style"


### PR DESCRIPTION
## module-name: Fix relative path

## Problem
1. Path is hardcoded and does not build correctly on production for the sub-navigation modules.
2. Color in hover effect for package guidelines does not match hover color in the rest of the site.

## Solution
- In `content/resources/packaging/index.md` change hardcoded paths to relative paths allowing `eleventy.js` to build correctly in production. Eleventy respects `pathPrefix` and treats hardcoded subnav paths as literal, changing to strings with no leading / should fix the issue.
- Change hover color to match color in `_colors.scss`

## Result
- URLs in sub-nav should work as intended in production.
- Colors match on hover. 

## Test Plan
- Test in dev
- Test in prod using npx serve _site                       