### PR TITLE
Frontend: Fix path for subnav links

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,4 +1,4 @@
-{% comment %} 
+{% comment %}
 The sidenav is not loaded by default on the main pages. To include this navigation you can either use the
 _layouts/page.html layout template, or you can add "sidenav: true" in the front-matter of your pages
 {% endcomment %}
@@ -7,32 +7,34 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
   <nav class="{% if sticky_sidenav %} position-sticky top-1 {% endif%} ">
     <ul class="usa-sidenav">
       {% if eleventyNavigation.parent %}
-        {% assign links = collections.all | eleventyNavigation: eleventyNavigation.parent %}
+      {% assign links = collections.all | eleventyNavigation: eleventyNavigation.parent %}
       {% else %}
-        {% assign links = collections[eleventyNavigation.key] | eleventyNavigation %}
+      {% assign links = collections[eleventyNavigation.key] | eleventyNavigation %}
       {% endif %}
       {% for link in links %}
-        {% assign _current = false %}
-        {% if link.url == page.url %}
-          {% assign _current = true %}
+      {% assign _current = false %}
+      {% if link.url == page.url %}
+      {% assign _current = true %}
+      {% endif %}
+      <li class="usa-sidenav__item">
+        <a href="{{ link.url | url }}" {% if _current %} class="usa-current" {% endif %}>
+          {{ link.title }}
+        </a>
+        {% if subnav and _current %}
+        {% for heading in subnav %}
+        <ul class="usa-sidenav__sublist">
+          <li class="usa-sidenav__item border-0">
+            {% if my_string[0] == "#" %}
+            <a href="{{ heading.href }}"> {{ heading.text }} </a>
+            {% else %}
+            <a href="{{ heading.href | url }}"> {{ heading.text }} </a>
+            {% endif %}
+          </li>
+        </ul>
+        {% endfor %}
         {% endif %}
-        <li class="usa-sidenav__item">
-          <a href="{{ link.url | url }}"
-             {% if _current %} class="usa-current" {% endif %}
-          >
-           {{ link.title }}
-          </a>
-          {% if subnav and _current %}
-            {% for heading in subnav %}
-            <ul class="usa-sidenav__sublist">
-              <li class="usa-sidenav__item border-0">
-                <a href="{{ heading.href }}"> {{ heading.text }} </a>
-              </li>
-            </ul>
-            {% endfor %}
-          {% endif %}
-        </li>
-    {% endfor %}
+      </li>
+      {% endfor %}
     </ul>
   </nav>
 </aside>

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -14,11 +14,11 @@ sidenav: true
 sticky_sidenav: true
 subnav:
   - text: Packaging Python Projects
-    href: 'resources/packaging/exporting-python-projects/'
+    href: '/resources/packaging/exporting-python-projects/'
   - text: Creating GitHub Repo Templates
-    href: 'resources/packaging/github-repo-template-guide/'
+    href: '/resources/packaging/github-repo-template-guide/'
   - text: Packaging JavaScript Projects
-    href: 'resources/packaging/npm-packaging-guidelines/'
+    href: '/resources/packaging/npm-packaging-guidelines/'
 ---
 
 ### Below are guides related to packaging and publishing projects:


### PR DESCRIPTION
## Frontend: Fix path for subnav links

## Problem
Currently, `hrefs` listed in the subnav of a guide only support links to headings (example: "#history-of-open-source-at-cms), but they do not support regular links (example: "/packaging-python-projects/).

## Solution

Add support for regular links by:
- If href includes "#", then it is a heading link else it is a regular link
- If it is a regular link, use the `url` filter which adds `pathPrefix` to href

## Result
Links in a subnav now work for heading links and regular links!

## Test Plan
- Check packaging guides at https://natalialuzuriaga.github.io/ospo-guide/resources/ to test regular links
- Check About guide at https://natalialuzuriaga.github.io/ospo-guide/about to test heading links
- Links test pass!