### PR TITLE
Remove categories and create new paths

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -108,13 +108,6 @@ module.exports = function (config) {
     return filterTagList([...tagSet]);
   });
 
-  // Add guides as collections
-  config.addCollection('packagingGuides', function (collectionApi) {
-    return collectionApi
-      .getFilteredByGlob('content/resources/packaging/*.md')
-      .filter(item => !item.inputPath.endsWith('index.md'));
-  });
-
   // Customize Markdown library and settings
   let markdownLibrary = markdownIt({
     html: true,

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -256,3 +256,7 @@ h2.heading-md {
     }
   }
 }
+
+#packaging-style:hover {
+  background-color: #f1f1f1;
+}

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -84,7 +84,6 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-
 // usa-section overrides
 .hero .section__heading--white {
   color: color('white');

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -256,6 +256,20 @@ h2.heading-md {
   }
 }
 
+#packaging-style {
+  color: #046b99;
+  font-size: 1.2rem; 
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  margin-left: -5%;
+  padding: 1.5%;
+  text-decoration: none;
+}
+
 #packaging-style:hover {
   background-color: #f1f1f1;
+}
+
+.packaging-list-style {
+  list-style: none; 
 }

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -24,13 +24,10 @@ console.log(subnav | log)
 
 ### Below are guides related to packaging and publishing projects:
 
-<ul style="list-style: none; padding-left: 0;">
+<ul class="packaging-list-style">
   {% for guide in subnav %}
-    <li style="margin-bottom: 0.5rem;">
-        <a href="{{ guide.href | url }}" id="packaging-style"
-          style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
-          color: #046b99; padding: 1.5%"
-        >
+    <li>
+        <a href="{{ guide.href | url }}" id="packaging-style">
           {{ guide.text }}
         </a>
     </li>

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -20,38 +20,19 @@ subnav:
   - text: Packaging JavaScript Projects
     href: '/resources/packaging/npm-packaging-guidelines/'
 ---
+console.log(subnav | log)
 
 ### Below are guides related to packaging and publishing projects:
 
 <ul style="list-style: none; padding-left: 0;">
+  {% for guide in subnav %}
     <li style="margin-bottom: 0.5rem;">
-        <a href="{{ '/resources/packaging/exporting-python-projects/' | url }}" id="packaging-style"
+        <a href="{{ guide.href | url }}" id="packaging-style"
           style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
           color: #046b99; padding: 1.5%"
         >
-          Packaging Python Projects
+          {{ guide.text }}
         </a>
     </li>
-    <li style="margin-bottom: 0.5rem;">
-        <a href="{{ '/resources/packaging/github-repo-template-guide/' | url }}" id="packaging-style"
-          style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
-          color: #046b99; padding: 1.5%"
-        >
-          Creating GitHub Repo Templates
-        </a>
-    </li>
-    <li style="margin-bottom: 0.5rem;">
-        <a href="{{ '/resources/packaging/npm-packaging-guidelines/' | url }}" id="packaging-style"
-          style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
-          color: #046b99; padding: 1.5%"
-        >
-          Packaging JavaScript Projects
-        </a>
-    </li>
+  {% endfor %}
 </ul>
-
-<style>
-  #packaging-style:hover {
-    background-color: #f1f1f1;
-  }
-</style>

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -20,7 +20,6 @@ subnav:
   - text: Packaging JavaScript Projects
     href: '/resources/packaging/npm-packaging-guidelines/'
 ---
-console.log(subnav | log)
 
 ### Below are guides related to packaging and publishing projects:
 

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -24,19 +24,34 @@ subnav:
 ### Below are guides related to packaging and publishing projects:
 
 <ul style="list-style: none; padding-left: 0;">
-{% for guide in collections.packagingGuides %}
-    <li>
-        <style>
-            #packaging-style:hover {
-                background-color: #f1f1f1;
-            }
-        </style>
-        <a href="{{ guide.url }}" id="packaging-style"
-          style="text-decoration: none; font-size: 1.2rem; font-weight: 600;
+    <li style="margin-bottom: 0.5rem;">
+        <a href="{{ '/resources/packaging/exporting-python-projects/' | url }}" id="packaging-style"
+          style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
           color: #046b99; padding: 1.5%"
         >
-          {{ guide.data.title }}
+          Packaging Python Projects
         </a>
     </li>
-{% endfor %}
+    <li style="margin-bottom: 0.5rem;">
+        <a href="{{ '/resources/packaging/github-repo-template-guide/' | url }}" id="packaging-style"
+          style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
+          color: #046b99; padding: 1.5%"
+        >
+          Creating GitHub Repo Templates
+        </a>
+    </li>
+    <li style="margin-bottom: 0.5rem;">
+        <a href="{{ '/resources/packaging/npm-packaging-guidelines/' | url }}" id="packaging-style"
+          style="text-decoration: none; font-size: 1.2rem; font-weight: 500;
+          color: #046b99; padding: 1.5%"
+        >
+          Packaging JavaScript Projects
+        </a>
+    </li>
 </ul>
+
+<style>
+  #packaging-style:hover {
+    background-color: #f1f1f1;
+  }
+</style>


### PR DESCRIPTION
## module-name: Create hardcoded path

## Problem
- When sub-nav is added to link paths, category collection logic becomes redundant

## Solution
- Remove collection logic from `eleventy.js`
- Add <li> links for each path

## Result
Paths should work as intended.

## Test Plan
Test in dev browser
Test on individual fork in prod