### PR TITLE
Resources: Created new Cybersecurity guide and update GitHub 101

### DIFF
--- a/content/resources/cybersecurity.md
+++ b/content/resources/cybersecurity.md
@@ -1,0 +1,21 @@
+---
+title: Cybersecurity at CMS
+description: 'Cybersecurity at CMS resources'
+permalink: /resources/cybersecurity
+layout: layouts/page
+section: resources
+tags: ospo
+eleventyNavigation:
+  parent: ospo-resources
+  key: ospo-resources-cybersecurity
+  order: 4
+  title: Cybersecurity
+sidenav: true
+sticky_sidenav: true
+---
+
+## CMS Cybergeek
+
+[Cybergeek](https://security.cms.gov/) contains various resources on keeping information  keeping information systems safe, secure, and compliant at CMS.
+
+- [GitHub Secret Scanning](https://security.cms.gov/posts/github-secret-scanning-enhancing-security-ars-compliance-and-zero-trust)

--- a/content/resources/github101.md
+++ b/content/resources/github101.md
@@ -18,7 +18,7 @@ sticky_sidenav: true
 
 1. [Git Terminology](#git-terminology)
 2. [GitHub Workflow: Making Changes to your Repository](#github-workflow-making-changes-to-your-repository)
-3. [CMS-Specific GitHub Resources](#github-workflow-making-changes-to-your-repository)
+3. [CMS-Specific GitHub Resources](#resources)
 
 ## Git Terminology
 
@@ -123,7 +123,9 @@ _Taken from [GitHub Docs](https://docs.github.com/en/get-started/quickstart/hell
 
 10. The team will then review the resulting pull request and merge dev into main once they are satisfied with the state of `dev`
 
-## CMS Specific GitHub Resources
+## Resources
+
+### CMS Specific GitHub Resources
 
 Instructions on accessing CMS Cloud GitHubs (CMSGov & OIT-Enterprise):
 [https://cloud.cms.gov/accessing-cms-cloud-github](https://cloud.cms.gov/accessing-cms-cloud-github)
@@ -133,3 +135,7 @@ Instructions on managing CMS Cloud GitHub repositories. Find guidance on creatin
 
 List of Repositories on CMS Cloud Github:
 [https://cloud.cms.gov/cms-cloud-github-repository-list](https://cloud.cms.gov/cms-cloud-github-repository-list)
+
+### GitHub Resources
+GitHub Secret Scanning:
+[https://security.cms.gov/posts/github-secret-scanning-enhancing-security-ars-compliance-and-zero-trust](https://security.cms.gov/posts/github-secret-scanning-enhancing-security-ars-compliance-and-zero-trust)

--- a/content/resources/glossary.md
+++ b/content/resources/glossary.md
@@ -8,7 +8,7 @@ tags: ospo
 eleventyNavigation:
   parent: ospo-resources
   key: ospo-resources-glossary
-  order: 7
+  order: 8
   title: Glossary
 sidenav: true
 sticky_sidenav: true

--- a/content/resources/user-guide-template.md
+++ b/content/resources/user-guide-template.md
@@ -8,7 +8,7 @@ tags: ospo
 eleventyNavigation:
   parent: ospo-resources
   key: ospo-resources-userguide
-  order: 6
+  order: 7
   title: User Guide Template
 sidenav: true
 sticky_sidenav: true

--- a/content/resources/user-stories-101.md
+++ b/content/resources/user-stories-101.md
@@ -8,7 +8,7 @@ tags: ospo
 eleventyNavigation:
   parent: ospo-resources
   key: ospo-resources-userstories
-  order: 5
+  order: 6
   title: User Story Writing 101
 sidenav: true
 sticky_sidenav: true

--- a/content/resources/xz-supply-chain-attack.md
+++ b/content/resources/xz-supply-chain-attack.md
@@ -8,7 +8,7 @@ tags: ospo
 eleventyNavigation:
   parent: ospo-resources
   key: ospo-resources-xz
-  order: 4
+  order: 5
   title: XZ Supply Chain Attack
 sidenav: true
 sticky_sidenav: true


### PR DESCRIPTION
## Resources: Created new Cybersecurity guide and update GitHub 101

## Problem

We would like to include a new guide about Cybersecurity at CMS and point to CMS' Cybergeek: https://security.cms.gov/

## Solution

- Created a new cybersecurity guide under resources
- Updated order numbers of guides under resources
- Added to GitHub 101 since it is relevant too