### PR TITLE
Add images as shortcode

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -33,13 +33,17 @@ async function imageWithClassShortcode(
   src,
   cls,
   alt,
+  evergreen = "true",
+  lastChecked = ""
 ) {
   const url = await imageUrl(src);
-  return `<img src="${url}" class="${cls}" alt="${alt}" loading="lazy" decoding="async">`;
+  const evergreenAttr = evergreen === "false" ? `data-evergreen="false"` : "";
+  const lastCheckedAttr = lastChecked ? `data-last-checked=${lastChecked}` : "";
+  return `<img src="${url}" class="${cls}" alt="${alt}" ${evergreenAttr} ${lastCheckedAttr} loading="lazy" decoding="async">`;
 }
 
-async function imageShortcode(src, alt) {
-  return await imageWithClassShortcode(src, '', alt);
+async function imageShortcode(src, alt, evergreen, lastChecked) {
+  return await imageWithClassShortcode(src, '', alt, evergreen, lastChecked);
 }
 
 module.exports = {

--- a/content/resources/beginner-guide-github-repos.md
+++ b/content/resources/beginner-guide-github-repos.md
@@ -33,27 +33,18 @@ This guide is an optional companion to repo-scaffolder. If you’ve never used G
 1. Go to [GitHub.com](https://github.com) and log in.   
     - You will need a GitHub account  
 2. Click the **\+** button (top right) → **New repository**. 
-<img src="/assets/_common/_img/add-repo-button-screenshot.png"
-    alt="Add a repo button"
-    width="1090"
-    data-evergreen="false"
-    data-last-checked="2025-10-08" />
+{% image_with_class 
+    "assets/_common/_img/add-repo-button-screenshot.png" "instructional-image" "Add a repo button" "false" "2025-10-08" %}
 
 3. Give your repository a name (for example: `my-project`).  
 4. Choose **Public**.
-<img src="/assets/_common/_img/public-button-screenshot.png"
-    alt="Public button"
-    width="1090"
-    data-evergreen="false"
-    data-last-checked="2025-10-08" />
+{% image_with_class 
+    "assets/_common/_img/public-button-screenshot.png" "instructional-image" "Public button" "false" "2025-10-08" %}
 
 5. (Optional) Check **Add a README file**.  
 6. Click **Create repository**.
-<img src="/assets/_common/_img/create-repo-button-screenshot.png"
-    alt="Create a repo button"
-    width="1090"
-    data-evergreen="false"
-    data-last-checked="2025-10-08" />
+{% image_with_class 
+    "assets/_common/_img/create-repo-button-screenshot.png" "instructional-image" "Create a repo button" "false" "2025-10-08" %}
 
 Your repo now exists on GitHub\! 
 


### PR DESCRIPTION
## module-name: Add images as shortcode

## Problem
Some images in the OSPO Guide reference documentation, tools, or UI screenshots that change over time. These  screenshots can become outdated without any clear way to identify or track them. This creates a maintenance risk, as outdated visuals may mislead users or reduce the accuracy of the guide.

## Solution
Add support for `data-evergreen` and `data-last-checked` attributes in the `image_with_class` shortcode.

These attributes allow maintainers to mark images that may become obsolete and record the last review date. This provides a structured way to identify non-evergreen images and enables future automation. 

**Example usage:**
```liquid
{% image_with_class 
    "assets/_common/_img/add-repo-button-screenshot.png" 
    "instructional-image" # class
    "Add a repo button" # alt
    "false" # data-evergreen
    "2025-10-08" # data-last-checked
%}
```

## Result
- The shortcode now supports `data-evergreen` and `data-last-checked` attributes.
- All images can optionally be annotated for tracking how fresh they are.
- Future automation can query these attributes to show outdated assets.
- No breaking changes to existing usage of the shortcode.

## Test Plan
1. Pull this branch and rebuild the Eleventy site locally
2. Add a test image using the updated shortcode with `data-evergreen="false"` and `data-last-checked="YYYY-MM-DD"`.
3. Inspect the generated HTML in `_site/` to verify both attributes appear correctly in the `<img>` tag. **(NOTE: image will not render if tag is implemented incorrectly)**
4. Confirm that existing images without attributes continue to render correctly.
5. Inspect browser DevTools to verify image rendering is unaffected.

## Next steps
- Implement a GitHub Action to detect and report images with `data-evergreen="false"` that may be out of date.
- (Optional/up for discussion) Add CSS styling or badges to visually mark non-evergreen images.