### PR TITLE
Add evergreen action

### DIFF
--- a/.github/scripts/check-evergreen.js
+++ b/.github/scripts/check-evergreen.js
@@ -1,0 +1,110 @@
+const fs = require("fs");
+const path = require("path");
+const { Octokit } = require("@octokit/action");
+
+const CONTENT_DIR = path.join(process.cwd(), "content");
+const ISSUE_TITLE = "🌲 Evergreen Image Review Required";
+const MONTHS_THRESHOLD = parseInt(process.env.THRESHOLD_MONTHS || "12", 10);
+const ISSUE_LABELS = (process.env.ISSUE_LABELS || "evergreen-review, maintenance,content-check").split(",").map((l) => l.trim());
+
+function getAllMarkdownFiles(dir) {
+    let results = [];
+    const list = fs.readdirSync(dir);
+    for (const file of list) {
+        const filePath = path.join(dir, file);
+        const stat = fs.statSync(filePath);
+        if (stat.isDirectory()) {
+            results = results.concat(getAllMarkdownFiles(filePath));
+        } else if (filePath.endsWith(".md")) {
+            results.push(filePath);
+        }
+    }
+
+    return results;
+}
+
+function monthsBetween(date1, date2) {
+    return (date2.getFullYear() - date1.getFullYear()) * 12 + (date2.getMonth() - date1.getMonth());
+}
+
+function checkFile(filePath) {
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split("\n");
+    const findings = [];
+
+    const shortcodeRegex = /{%\s*image_with_class\s+[^%]*?"(false|true|[^"]*)?"\s+"?(\d{4}-\d{2}-\d{2})?"?\s*%}/g;
+
+    lines.forEach((line, i) => {
+        const matches = [...line.matchAll(shortcodeRegex)];
+        for (const match of matches) {
+            const lastChecked = match[2];
+            if (!lastChecked) {
+                findings.push({ filePath, line: i + 1, lastChecked: "missing" });
+            } else {
+                const date = new Date(lastChecked);
+                if (isNaN(date)) {
+                    findings.push({ filePath, line: i + 1, lastChecked: "invalid format" });
+                    continue;
+                }
+                const monthsOld = monthsBetween(date, new Date());
+                if (monthsOld >= MONTHS_THRESHOLD) {
+                    findings.push({ filePath, line: i + 1, lastChecked });
+                }
+            }
+        }
+    });
+
+    return findings;
+}
+
+async function createOrUpdateIssue(findings) {
+   const octokit = new Octokit(); 
+   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+   const issueBody = [
+    `### Evergreen image tags need review\n`,
+    `The following images are over **${MONTHS_THRESHOLD} months old** or missing a \`lastChecked\` date:\n`,
+    ...findings.map((finding) => `- \`${finding.filePath}\`: line ${finding.line} - lastChecked: **${finding.lastChecked}**`),
+    "\nPlease review and update these images or confirm they are still current."
+   ].join("\n");
+
+   const existing = await octokit.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: "open"
+   });
+
+   const existingIssue = existing.data.find((issue) => issue.title === ISSUE_TITLE);
+
+   if (existingIssue) {
+    await octokit.rest.issues.update({
+        owner,
+        repo,
+        issue_number: existingIssue.number,
+        body: issueBody,
+        labels: ISSUE_LABELS
+    });
+    console.log("✅ Created new evergreen issue.");
+   }
+};
+
+(async function run() {
+    try {
+        const files = getAllMarkdownFiles(CONTENT_DIR);
+        let allFindings = [];
+        for (const f of files) {
+            allFindings = allFindings.concat(checkFile(f));
+        }
+
+        if (allFindings.length === 0) {
+            console.log("🎉 All evergreen tags are up to date!");
+            return;
+        }
+
+        console.log(`Found ${allFindings.length} outdate/missing evergreen tags.`);
+        await createOrUpdateIssue(allFindings);
+    } catch (err) {
+        console.error("❌ Error running evergreen check:", err);
+        process.exit(1);
+    }
+})();

--- a/.github/workflows/evergreen-check.yml
+++ b/.github/workflows/evergreen-check.yml
@@ -1,0 +1,43 @@
+name: Evergreen Image Tag Check
+
+on:
+  schedule:
+    - cron: "0 0 1 1 *"
+  workflow_dispatch:
+    inputs:
+      threshold_months:
+        description: "Sets how many months before an image is considered outdated"
+        required: false
+        default: "12"
+        type: choice
+        options:
+          - "6"
+          - "12"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-evergreen:
+    name: Check Evergreen Image Dates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+                
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Octokit dependency
+        run: npm install @octokit/action
+
+      - name: Run evergreen check
+        run: node .github/scripts/check-evergreen.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THRESHOLD_MONTHS: ${{ inputs.threshold_months || '12' }}
+          ISSUE_LABELS: evergreen-review, maintenance, content-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@11ty/eleventy-fetch": "^5.1.0",
         "@11ty/eleventy-img": "^3.1.8",
+        "@octokit/action": "^8.0.4",
+        "@octokit/rest": "^22.0.1",
         "@uswds/uswds": "3.9.0",
         "autoprefixer": "^10.4.20",
-        "dotenv": "^16.5.0",
+        "dotenv": "^16.6.1",
         "esbuild": "^0.24.0",
         "esbuild-sass-plugin": "^3.3.1",
         "luxon": "^2.3.1",
@@ -1236,6 +1238,190 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/action": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-8.0.4.tgz",
+      "integrity": "sha512-1qFYTCrShafc5fQaEbLNUo4xIi/nf98R8iAcJ0ITTCfoRnei9g5Ss9kGkN2tOA7gBlI4HB08Seub4navWXSSbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-action": "^6.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/types": "^16.0.0",
+        "undici": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-action": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-6.0.2.tgz",
+      "integrity": "sha512-gEBsz0QioHOMoEU7u2VMr2FfOvfJCrGc42K9rliS7LnlZJLcEMFccIiCiPpPNH+yXs7YYNKQ7lOX67ZTWn6Ysg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
+      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.6.tgz",
+      "integrity": "sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.2.tgz",
+      "integrity": "sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1941,6 +2127,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -3425,9 +3617,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -4331,6 +4524,22 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10215,6 +10424,21 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,11 @@
   "dependencies": {
     "@11ty/eleventy-fetch": "^5.1.0",
     "@11ty/eleventy-img": "^3.1.8",
+    "@octokit/action": "^8.0.4",
+    "@octokit/rest": "^22.0.1",
     "@uswds/uswds": "3.9.0",
     "autoprefixer": "^10.4.20",
-    "dotenv": "^16.5.0",
+    "dotenv": "^16.6.1",
     "esbuild": "^0.24.0",
     "esbuild-sass-plugin": "^3.3.1",
     "luxon": "^2.3.1",


### PR DESCRIPTION
## module-name: Add GitHub Action for evergreen tags

## Problem
Over time, images in repositories can become outdated and OSPO-Guide needs to stay up to date to ensure accurate information. To prevent outdated image shortcodes and stale evergreen tags, a periodic automated check is needed. Manually reviewing images every few months is inefficient and prone to error. 

## Solution
- `scripts/check-evergreen.js` added to scan markdown files and liquid files for `{% image_with_class %}` shortcodes with an evergreen tag and date.
  - This node script isolates the business logic from the workflow action. This makes it easier to:
    - Test locally
    - Reuse the script or expand it later
    - Keep the YAML concise, ensuring it does not become brittle
- `workflows/evergreen-check.yml` that runs every 6 or 12 months added
- Configurable threshold via `MONTHS_THRESHOLD` environmental variable added
- **Octokit** is used to create or update issues, if stale tags are detected
- Updated `package.json` `dotenv`

## Result
- The script scans all content files for evergreen shortcodes
- If any are older than the set threshold, the workflow posts/updates a GitHub issue listing the affected files
- Each issue is automatically labeled

## Test Plan
Test locally:
```bash
# Install dependencies
npm install @octokit/rest dotenv

# Add .env if needed
GITHUB_TOKEN=<your-token>

# Run script
node .github/scripts/check-evergreen.js
```

Validate workflow syntax:
```bash
npm install -g actionlint

# To run:
actionlint .github/workflows/evergreen-check.yml
```