### PR TITLE
Create sub module guide

### DIFF
--- a/.github/scripts/check-evergreen.js
+++ b/.github/scripts/check-evergreen.js
@@ -1,0 +1,110 @@
+const fs = require("fs");
+const path = require("path");
+const { Octokit } = require("@octokit/action");
+
+const CONTENT_DIR = path.join(process.cwd(), "content");
+const ISSUE_TITLE = "🌲 Evergreen Image Review Required";
+const MONTHS_THRESHOLD = parseInt(process.env.THRESHOLD_MONTHS || "12", 10);
+const ISSUE_LABELS = (process.env.ISSUE_LABELS || "evergreen-review, maintenance,content-check").split(",").map((l) => l.trim());
+
+function getAllMarkdownFiles(dir) {
+    let results = [];
+    const list = fs.readdirSync(dir);
+    for (const file of list) {
+        const filePath = path.join(dir, file);
+        const stat = fs.statSync(filePath);
+        if (stat.isDirectory()) {
+            results = results.concat(getAllMarkdownFiles(filePath));
+        } else if (filePath.endsWith(".md")) {
+            results.push(filePath);
+        }
+    }
+
+    return results;
+}
+
+function monthsBetween(date1, date2) {
+    return (date2.getFullYear() - date1.getFullYear()) * 12 + (date2.getMonth() - date1.getMonth());
+}
+
+function checkFile(filePath) {
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split("\n");
+    const findings = [];
+
+    const shortcodeRegex = /{%\s*image_with_class\s+[^%]*?"(false|true|[^"]*)?"\s+"?(\d{4}-\d{2}-\d{2})?"?\s*%}/g;
+
+    lines.forEach((line, i) => {
+        const matches = [...line.matchAll(shortcodeRegex)];
+        for (const match of matches) {
+            const lastChecked = match[2];
+            if (!lastChecked) {
+                findings.push({ filePath, line: i + 1, lastChecked: "missing" });
+            } else {
+                const date = new Date(lastChecked);
+                if (isNaN(date)) {
+                    findings.push({ filePath, line: i + 1, lastChecked: "invalid format" });
+                    continue;
+                }
+                const monthsOld = monthsBetween(date, new Date());
+                if (monthsOld >= MONTHS_THRESHOLD) {
+                    findings.push({ filePath, line: i + 1, lastChecked });
+                }
+            }
+        }
+    });
+
+    return findings;
+}
+
+async function createOrUpdateIssue(findings) {
+   const octokit = new Octokit(); 
+   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+   const issueBody = [
+    `### Evergreen image tags need review\n`,
+    `The following images are over **${MONTHS_THRESHOLD} months old** or missing a \`lastChecked\` date:\n`,
+    ...findings.map((finding) => `- \`${finding.filePath}\`: line ${finding.line} - lastChecked: **${finding.lastChecked}**`),
+    "\nPlease review and update these images or confirm they are still current."
+   ].join("\n");
+
+   const existing = await octokit.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: "open"
+   });
+
+   const existingIssue = existing.data.find((issue) => issue.title === ISSUE_TITLE);
+
+   if (existingIssue) {
+    await octokit.rest.issues.update({
+        owner,
+        repo,
+        issue_number: existingIssue.number,
+        body: issueBody,
+        labels: ISSUE_LABELS
+    });
+    console.log("✅ Created new evergreen issue.");
+   }
+};
+
+(async function run() {
+    try {
+        const files = getAllMarkdownFiles(CONTENT_DIR);
+        let allFindings = [];
+        for (const f of files) {
+            allFindings = allFindings.concat(checkFile(f));
+        }
+
+        if (allFindings.length === 0) {
+            console.log("🎉 All evergreen tags are up to date!");
+            return;
+        }
+
+        console.log(`Found ${allFindings.length} outdate/missing evergreen tags.`);
+        await createOrUpdateIssue(allFindings);
+    } catch (err) {
+        console.error("❌ Error running evergreen check:", err);
+        process.exit(1);
+    }
+})();

--- a/.github/workflows/evergreen-check.yml
+++ b/.github/workflows/evergreen-check.yml
@@ -1,0 +1,43 @@
+name: Evergreen Image Tag Check
+
+on:
+  schedule:
+    - cron: "0 0 1 1 *"
+  workflow_dispatch:
+    inputs:
+      threshold_months:
+        description: "Sets how many months before an image is considered outdated"
+        required: false
+        default: "12"
+        type: choice
+        options:
+          - "6"
+          - "12"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-evergreen:
+    name: Check Evergreen Image Dates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+                
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Octokit dependency
+        run: npm install @octokit/action
+
+      - name: Run evergreen check
+        run: node .github/scripts/check-evergreen.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THRESHOLD_MONTHS: ${{ inputs.threshold_months || '12' }}
+          ISSUE_LABELS: evergreen-review, maintenance, content-check

--- a/content/resources/packaging/git-submodule-guide.md
+++ b/content/resources/packaging/git-submodule-guide.md
@@ -1,0 +1,546 @@
+---
+title: Creating Git Submodules
+description: 'Guidelines for Git Submodules'
+permalink: /resources/packaging/git-submodule-guide/
+layout: layouts/page
+section: resources
+tags: ospo
+hideFromResources: true
+eleventyNavigation:
+  parent: ospo-resources-packaging
+  key: ospo-resources-packaging-exporting
+  order: 4
+  title: Creating Git Submodule Projects
+sidenav: true
+sticky_sidenav: true
+---
+
+# **Git Submodules 101: A Practical Guide for Metrics**
+
+## **What is a Git Submodule?**
+
+A Git submodule is a way to include a Git repository inside another Git repository, while keeping their histories completely separate.
+
+Example:
+
+* **Without submodules**: Copy/paste code from one project into another. When the original updates, the copy doesn't automatically get those updates.  
+* **With submodules**: Link to another repository. The code appears in the project, but lives in its own separate repository with its own version history.
+
+## **Why Use Submodules for Metrics**
+
+### **The Problem**
+
+**Before submodules:**
+
+```bash
+metrics/ (one big repo)
+├── app/ (frontend)
+├── scripts/ (backend)
+└── templates/ (backend)
+
+The problem: We need two sites (internal and external) with the same frontend
+```
+
+If we copied the frontend into two repos, we'd have:
+
+* Duplicate code to maintain  
+* Bug fixes needed in two places  
+* Feature updates needed in two places  
+* Inconsistent UIs between internal and external sites
+
+**After submodules:**
+
+```bash
+metrics-frontend/  (one source of truth)
+└── app/
+
+metrics-external/  (uses frontend)
+├── scripts/
+├── frontend/ → metrics-frontend (submodule)
+└── templates/
+
+metrics-internal/  (uses same frontend)
+├── scripts/
+├── frontend/ → metrics-frontend (submodule)
+└── templates/
+```
+
+Now:
+
+* ✅ Frontend code exists in ONE place  
+* ✅ Update frontend once, both backends get it  
+* ✅ Consistent UI across internal and external sites  
+* ✅ Frontend can be developed and tested independently
+
+---
+
+## **How Submodules Work: The Technical Details**
+
+### **What Gets Stored Where**
+
+When you add a submodule, Git stores:
+
+**In the parent repository (.git/):**
+
+* A reference to the submodule repository URL  
+* A specific commit SHA that the submodule should be at  
+  * SHA \- Secure Hash Algorithm in Git is a unique, 40-character hexadecimal string that acts as a cryptographic checksum, serving as a unique identifier for a particular commit in a Git repository  
+* Configuration in `.gitmodules` file
+
+**In the working directory:**
+
+* The actual submodule files (cloned from the other repo)
+
+**What this means:**
+
+* The parent repo doesn't contain the submodule's code  
+* It only contains a "pointer" saying: "At this location, use this repository at this commit"  
+* When you clone the parent, you need to tell Git to also fetch the submodule
+
+### **The .gitmodules File**
+
+After running \``` git submodule add` ``, Git creates a `.gitmodules` file:
+
+```bash
+[submodule "frontend"]
+    path = frontend
+    url = https://github.com/DSACMS/metrics_frontend.git
+    branch = main
+```
+
+This tells Git:
+
+* **submodule name**: "frontend"  
+* **path**: Where to put it in your repo (the `frontend/` folder)  
+* **url**: Where to clone it from  
+* **branch**: Which branch to track (optional)
+
+### **Commit References**
+
+The parent repository tracks a specific commit of the submodule. When you look at `git status`:
+
+```bash
+$ git status
+On branch main
+Changes not staged for commit:
+  modified: frontend (new commits)
+```
+
+This means:
+
+* Your submodule has newer commits available  
+* The parent is still pointing to an older commit  
+* You need to decide if you want to update the reference
+
+---
+
+## **Common Submodule Commands for Daily Work**
+
+### **Initial Setup (One Time)**
+
+**Adding a submodule:**
+
+```bash
+git submodule add https://github.com/DSACMS/metrics_frontend.git frontend
+git commit -m "Add frontend submodule"
+git push
+```
+
+**Cloning a repo with submodules:**
+
+```bash
+# Option 1: Clone and get submodules at once
+git clone --recursive https://github.com/DSACMS/metrics.git
+
+# Option 2: Clone first, then get submodules
+git clone https://github.com/DSACMS/metrics.git
+cd metrics
+git submodule update --init --recursive
+```
+
+### **Daily Development**
+
+**Updating the submodule to latest:**
+
+```bash
+cd frontend
+git pull origin main
+cd ..
+git add frontend
+git commit -m "Update frontend submodule to latest"
+git push
+```
+
+**Making changes to the submodule:**
+
+```bash
+cd frontend
+git checkout -b feature/change
+# Make the change changes
+git add .
+git commit -m "Add new feature"
+git push origin feature/my-change
+# Create PR in metrics_frontend repo
+```
+
+**After teammate updates the submodule:**
+
+```bash
+git pull
+git submodule update --remote
+```
+
+---
+
+## **Metrics Workflow**
+
+### **Scenario 1: Fixing a Frontend Bug**
+
+**Problem:** The navigation bar has a broken link
+
+**Steps:**
+
+```bash
+# 1. Navigate into the submodule
+cd metrics/frontend
+
+# 2. Create a branch (best practice)
+git checkout -b fix/nav-broken-link
+
+# 3. Fix the bug in app/site/_includes/nav.liquid
+# (edit the file)
+
+# 4. Commit in the submodule
+git add app/site/_includes/nav.liquid
+git commit -m "Fix broken link in navigation"
+git push origin fix/nav-broken-link
+
+# 5. Create PR in metrics-frontend repo
+# (go to GitHub and create PR)
+
+# 6. After PR merges, update both backends
+cd metrics/frontend
+git checkout main
+git pull origin main
+cd ../..
+git add frontend
+git commit -m "Update frontend with nav fix"
+git push
+
+# Do the same for the metrics internal site
+```
+
+**Result:** Bug fixed once, both internal and external sites are fixed.
+
+### **Scenario 2: Adding a New Data Source (Backend Only)**
+
+**Problem:** Need to add OpenSSF scorecard data to external site
+
+**Steps:**
+
+```bash
+# 1. Work in the backend repo
+cd metrics (external)
+
+# 2. Create feature branch
+git checkout -b feature/add-ossf-scorecard
+
+# 3. Add new Python script
+# scripts/fetch_ossf_scorecard.py 
+
+# 4. Update data generation to output to frontend
+# Make sure script writes to: frontend/app/site/_data/ossf_scores.json
+
+# 5. Test locally
+python scripts/fetch_ossf_scorecard.py
+cd frontend/app
+npm start
+# Verify data appears in UI
+
+# 6. Commit backend changes only
+cd ../..
+git add scripts/
+git commit -m "Add OpenSSF scorecard data fetching"
+git push origin feature/add-ossf-scorecard
+
+# 7. Create PR in metrics (external) repo
+```
+
+**Result:** New data added to external backend, frontend displays it automatically\!
+
+### **Scenario 3: Frontend Needs New Data Structure**
+
+**Problem:** Frontend wants to show commit frequency, but backend doesn't provide it yet
+
+**Coordination needed:**
+
+```bash
+# Backend :
+cd metrics (external)
+git checkout -b feature/add-commit-frequency
+# Add to scripts/refresh_metrics.py to generate commit_frequency.json
+# Output to: frontend/app/site/_data/commit_frequency.json
+git commit -m "Add commit frequency data generation"
+
+# Frontend:
+cd metrics_frontend
+git checkout -b feature/show-commit-frequency
+# Update app/site/index.liquid to display commit_frequency.json
+git commit -m "Add commit frequency visualization"
+
+# Both create PRs, test together, merge when ready
+```
+
+---
+
+## **Understanding Submodule States**
+
+### **The Three States**
+
+1. **Uninitialized**: Submodule exists in `.gitmodules` but folder is empty
+
+```bash
+git submodule update --init
+```
+
+2. **Initialized but outdated**: Submodule folder has old commits
+
+```bash
+git submodule update --remote
+```
+
+3. **Up to date**: Submodule is at the commit the parent expects
+
+```bash
+# No action needed
+```
+
+### **Checking Submodule Status**
+
+```bash
+# In parent repo root
+git submodule status
+
+# Output examples:
+-a1b2c3d frontend (heads/main)         # Uninitialized (minus sign)
+ a1b2c3d frontend (heads/main)         # Initialized, up to date (space)
++a1b2c3d frontend (heads/main)         # Initialized, has new commits (plus)
+```
+
+---
+
+## **Common Pitfalls and How to Avoid Them**
+
+### **Pitfall 1: Forgetting to Initialize Submodules**
+
+**Symptom:** You clone the repo and `frontend/` folder is empty
+
+**Solution:**
+
+```bash
+git submodule update --init --recursive
+```
+
+**Prevention:** Always clone with `--recursive` flag:
+
+```bash
+git clone --recursive [repo-url]
+```
+
+### **Pitfall 2: Making Changes in Submodule but Not Committing**
+
+**Symptom:** You edit files in `frontend/`, but changes disappear after `git submodule update`
+
+**Why it happens:** Submodules are separate repositories. Changes in the submodule need to be committed in the submodule.
+
+**Solution:**
+
+```bash
+cd frontend
+git status  # See what changed
+git add .
+git commit -m "My changes"
+git push origin [branch-name]
+```
+
+### **Pitfall 3: Submodule Shows as "Modified" but You Didn't Change It**
+
+**Symptom:** \``` git status` `` shows \` `` modified: frontend (new commits)` ``
+
+**Why it happens:** Someone else updated the submodule to a newer commit. Your local copy is behind.
+
+**Solution:**
+
+```bash
+# Option 1: Update to the commit the parent expects
+git submodule update
+
+# Option 2: Update to latest and update parent
+cd frontend
+git pull origin main
+cd ..
+git add frontend
+git commit -m "Update frontend submodule"
+```
+
+### **Pitfall 4: Detached HEAD State**
+
+**Symptom:** You're in the submodule and Git says "You are in 'detached HEAD' state"
+
+**Why it happens:** Submodules by default checkout a specific commit, not a branch.
+
+**Solution:** Before making changes, always checkout a branch:
+
+```bash
+cd frontend
+git checkout main
+# or
+git checkout -b feature/my-feature
+```
+
+### **Pitfall 5: Pushing Parent Before Submodule**
+
+**Symptom:** You update the submodule reference in parent repo, but submodule changes aren't pushed yet. Teammates can't clone your work.
+
+**Prevention:**
+
+```bash
+# Always push in this order:
+cd frontend
+git push origin [branch]  # Push submodule first
+cd ..
+git push origin [branch]  # Then push parent
+```
+
+---
+
+## **Advantages of Submodule Structure**
+
+### **For Metrics**
+
+1. **Single Source of Truth**  
+   * Frontend code lives in one place  
+   * Bug fixes propagate to all backends  
+   * UI consistency guaranteed  
+2. **Independent Development**  
+   * Frontend can work on UI without touching data logic  
+   * Backend can work on data generation without touching UI  
+   * Separate version control histories  
+3. **Easy to Scale**  
+   * Want a third backend (maybe for specific project types)? Just add the submodule  
+   * No code duplication  
+4. **Clear Separation of Concerns**  
+   * `metrics_frontend`: "How do we display data?"  
+   * `metrics (external)`: "What data do we show for public repos?"  
+   * `metrics (internal)`: "What data do we show for private repos?"  
+5. **Better Code Reviews**  
+   * Frontend PRs only review UI/UX changes  
+   * Backend PRs only review data generation logic  
+   * Reviewers can focus on their area of expertise
+
+---
+
+## **Submodules vs Other Approaches**
+
+### **Why Not Just Copy the Code?**
+
+**Copying:**
+
+```bash
+metrics-data-external/
+└── frontend/ (copied code)
+
+metrics-data-internal/
+└── frontend/ (copied code)
+```
+
+**Problems:**
+
+* Fix a bug in one, manually copy to the other  
+* UIs can drift apart over time  
+* Double the maintenance work
+
+### **Why Not Use npm Package?**
+
+**npm package approach:**
+
+```bash
+npm install DSACMS/metrics_frontend
+```
+
+**Why we didn't:**
+
+* Our frontend isn't just JavaScript, it's Liquid templates, Eleventy config, CSS  
+* Need the full source for Eleventy to build  
+* Submodules are simpler for full-stack apps  
+* Don't need npm registry overhead
+
+## **Quick Reference**
+
+### **Essential Commands**
+
+```bash
+# Adding a submodule
+git submodule add [url] [path]
+
+# Cloning with submodules
+git clone --recursive [repo-url]
+
+# Initialize submodules in existing clone
+git submodule update --init --recursive
+
+# Update submodule to latest
+cd [submodule-path]
+git pull origin main
+cd ..
+git add [submodule-path]
+git commit -m "Update submodule"
+
+# Update all submodules to latest
+git submodule update --remote
+
+# See submodule status
+git submodule status
+
+# Work on submodule
+cd [submodule-path]
+git checkout -b feature/my-feature
+# Make changes
+git commit -m "My changes"
+git push origin feature/my-feature
+```
+
+---
+
+## **Learn More**
+
+**Official Git Documentation:**
+
+* [Git Submodules Book](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+
+**Tips:**
+
+* Always commit and push submodule changes before pushing parent repo  
+* Use branches in submodules, avoid detached HEAD  
+* Document submodule workflow in your README  
+* Consider using \```git config submodule.recurse` true`` for automatic updates
+
+---
+
+## **Summary**
+
+For Metrics:
+
+* **metrics\_frontend** \= The reusable UI component  
+* **metrics (external)** \= Backend that includes frontend as submodule  
+* **metrics (internal**) \= Internal backend that includes the same frontend
+
+This structure gives us:
+
+* ✅ One frontend, multiple backends  
+* ✅ Independent development workflows  
+* ✅ Consistent UI across all sites  
+* ✅ Clear separation of concerns  
+* ✅ Easy maintenance and updates
+
+Git submodules are perfect for this use case where we need to share a complete application (not just a library) across multiple parent projects while maintaining separate version histories.

--- a/content/resources/packaging/npm-packaging-guidelines.md
+++ b/content/resources/packaging/npm-packaging-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: Packaging JavaScript Projects
-description: 'Guidelines for publishing python projects as packages'
+description: 'Guidelines for publishing JavaScript projects as packages'
 permalink: /resources/packaging/npm-packaging-guidelines/
 layout: layouts/page
 section: resources

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@11ty/eleventy-fetch": "^5.1.0",
         "@11ty/eleventy-img": "^3.1.8",
+        "@octokit/action": "^8.0.4",
+        "@octokit/rest": "^22.0.1",
         "@uswds/uswds": "3.9.0",
         "autoprefixer": "^10.4.20",
-        "dotenv": "^16.5.0",
+        "dotenv": "^16.6.1",
         "esbuild": "^0.24.0",
         "esbuild-sass-plugin": "^3.3.1",
         "luxon": "^2.3.1",
@@ -1236,6 +1238,190 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/action": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-8.0.4.tgz",
+      "integrity": "sha512-1qFYTCrShafc5fQaEbLNUo4xIi/nf98R8iAcJ0ITTCfoRnei9g5Ss9kGkN2tOA7gBlI4HB08Seub4navWXSSbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-action": "^6.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/types": "^16.0.0",
+        "undici": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-action": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-6.0.2.tgz",
+      "integrity": "sha512-gEBsz0QioHOMoEU7u2VMr2FfOvfJCrGc42K9rliS7LnlZJLcEMFccIiCiPpPNH+yXs7YYNKQ7lOX67ZTWn6Ysg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
+      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.6.tgz",
+      "integrity": "sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.2.tgz",
+      "integrity": "sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1941,6 +2127,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -3425,9 +3617,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -4331,6 +4524,22 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10215,6 +10424,21 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,11 @@
   "dependencies": {
     "@11ty/eleventy-fetch": "^5.1.0",
     "@11ty/eleventy-img": "^3.1.8",
+    "@octokit/action": "^8.0.4",
+    "@octokit/rest": "^22.0.1",
     "@uswds/uswds": "3.9.0",
     "autoprefixer": "^10.4.20",
-    "dotenv": "^16.5.0",
+    "dotenv": "^16.6.1",
     "esbuild": "^0.24.0",
     "esbuild-sass-plugin": "^3.3.1",
     "luxon": "^2.3.1",


### PR DESCRIPTION
## module-name: Submodule Guide

## Problem
Sometimes an NPM or PyPi package won't work. Specifically for fully functional applications. This is where Git Submodules come in. Creating a submodule can be more complicated than expected. The OSPO had no guidance on how to do this, particularly for DSAC projects.

## Solution
- Create documentation to help users familiarize themselves with Git submodules and their uses. 
- Fix typo in NPM Packaging Guidelines 

## Result
Now robust directions and guides exist for creating submodules

## Test Plan
To test:
```bash
npm run build
npm run dev
```

This was tested in the browser