### PR TITLE
Workflows: Fix pa11y errors

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,7 +10,7 @@ const markdownItFootnote = require('markdown-it-footnote');
 const { readableDate, htmlDateString, head, min, filterTagList } = require("./config/filters");
 const { headingLinks } = require("./config/headingLinks");
 const { contrastRatio, humanReadableContrastRatio } = require("./config/wcagColorContrast");
-const privateLinks = require ('./config/privateLinksList.js');
+const privateLinks = require('./config/privateLinksList.js');
 const svgSprite = require("eleventy-plugin-svg-sprite");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const yaml = require("js-yaml");
@@ -29,14 +29,14 @@ module.exports = function (config) {
   config.addPassthroughCopy('robots.txt');
 
   // Copy USWDS init JS so we can load it in HEAD to prevent banner flashing
-  config.addPassthroughCopy({'./node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js'});
+  config.addPassthroughCopy({ './node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js' });
 
   // Specific scripts to guides
   config.addPassthroughCopy("./assets/_common/js/*");
   config.addPassthroughCopy("./assets/**/js/*");
 
-  config.addPassthroughCopy({'./assets/_common/_img/favicons/favicon.ico': './favicon.ico' });
-  config.addPassthroughCopy({'./assets/_common/_img/favicons': './img/favicons' });
+  config.addPassthroughCopy({ './assets/_common/_img/favicons/favicon.ico': './favicon.ico' });
+  config.addPassthroughCopy({ './assets/_common/_img/favicons': './img/favicons' });
   config.addPassthroughCopy("assets");
 
   // Set download paths
@@ -90,7 +90,7 @@ module.exports = function (config) {
     return value.toUpperCase();
   });
 
-  config.addFilter("capitalize", (value) =>{
+  config.addFilter("capitalize", (value) => {
     return value.charAt(0).toUpperCase() + value.slice(1);
   });
 
@@ -117,20 +117,20 @@ module.exports = function (config) {
   }).use(markdownItAnchor, {
     permalink: headingLinks,
     slugify: config.getFilter('slugify'),
-  }).use(markdownItAttrs).use(markdownItFootnote).use(markdownItTaskLists);
+  }).use(markdownItAttrs).use(markdownItFootnote).use(markdownItTaskLists, { label: true });
   config.setLibrary('md', markdownLibrary);
 
   // Override Footnote opener
   markdownLibrary.renderer.rules.footnote_block_open = () => (
-  '<section class="footnotes">\n' +
-  '<ol class="footnotes-list">\n'
+    '<section class="footnotes">\n' +
+    '<ol class="footnotes-list">\n'
   );
 
   // Add icons for links with locked resources and external links
   // https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md
   // Token methods:  https://github.com/markdown-it/markdown-it/blob/master/lib/token.js#L125
   const openDefaultRender = markdownLibrary.renderer.rules.link_open ||
-    function(tokens, idx, options, env, self) {
+    function (tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
 
@@ -139,10 +139,10 @@ module.exports = function (config) {
     let prefixIcon = '';
     if (privateLinks.some((link) => token.attrGet('href').indexOf(link) >= 0)) {
       prefixIcon = '<span class="usa-sr-only"> 18F only, </span>' +
-                   '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
-                   'aria-hidden="true" role="img">' +
-                   '<use xlink:href="#svg-lock_outline"></use>' +
-                   '</svg>'
+        '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
+        'aria-hidden="true" role="img">' +
+        '<use xlink:href="#svg-lock_outline"></use>' +
+        '</svg>'
     }
 
     // Check for external URLs. External means any site that is not a federal .gov url
@@ -166,7 +166,7 @@ module.exports = function (config) {
   };
 
   const defaultHtmlBlockRender = markdownLibrary.renderer.rules.html_block ||
-    function(tokens, idx, options, env, self) {
+    function (tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
 
@@ -213,26 +213,26 @@ module.exports = function (config) {
 
   // Also need to add icon links to any html style links
   const inlineHTMLDefaultRender = markdownLibrary.renderer.rules.html_inline ||
-    function(tokens, idx, options, env, self) {
+    function (tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
 
   const linkOpenRE = /^<a[>\s]/i;
   markdownLibrary.renderer.rules.html_inline = (tokens, idx, options, env, self) => {
-    const token=tokens[idx];
+    const token = tokens[idx];
     if (linkOpenRE.test(token.content) && token.content.includes('http')) {
       let content = token.content;
 
       //Add private link icon
       const hrefRE = /href=\"([^"]*)/;
       // get the matching capture group
-      const contentUrl =  content.match(hrefRE)[1];
+      const contentUrl = content.match(hrefRE)[1];
       if (privateLinks.some((privateLink) => contentUrl.indexOf(privateLink) >= 0)) {
         const prefixIcon = '<span class="usa-sr-only"> 18F only, </span>' +
-                           '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
-                           'aria-hidden="true" role="img">' +
-                           '<use xlink:href="#svg-lock_outline"></use>' +
-                           '</svg>'
+          '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
+          'aria-hidden="true" role="img">' +
+          '<use xlink:href="#svg-lock_outline"></use>' +
+          '</svg>'
         content = content.replace('>', `> ${prefixIcon}`);
         tokens[idx].content = content;
       }

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -1,5 +1,5 @@
 @use '../../_common/styles/brand-colors' as *;
-@use 'uswds-core' as * ;
+@use 'uswds-core' as *;
 
 $bullet-spacing: 1.25rem;
 
@@ -10,7 +10,7 @@ a[href*="/TODO/"] {
   background-color: color('gold-10v') !important;
   padding: 0 units(0.5);
 
-  &:after  {
+  &:after {
     content: ' [link TBD]';
   }
 
@@ -18,6 +18,7 @@ a[href*="/TODO/"] {
     color: color('blue-80v') !important;
   }
 }
+
 .todo-link.usa-link--external:after,
 a[href*="/TODO/"].usa-link--external:after {
   background-color: inherit;
@@ -29,7 +30,12 @@ a[href*="/TODO/"].usa-link--external:after {
 }
 
 // Set heading colors
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   color: color('primary-darker');
 }
 
@@ -62,16 +68,22 @@ h1, h2, h3, h4, h5, h6 {
     word-wrap: break-word;
   }
 
-  h2, h3, h4, h5, h6 {
-      // prevent orphans and use balance if pretty is not available
-      text-wrap: balance;
-      text-wrap: pretty;
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    // prevent orphans and use balance if pretty is not available
+    text-wrap: balance;
+    text-wrap: pretty;
   }
 
   h2 {
     margin-top: units(5);
+
     &.page-title {
       margin-top: units(0);
+
       &.derisking {
         padding-top: units(1);
         border-top: 1px solid #1C304A;
@@ -116,11 +128,11 @@ a.usa-button--accent {
 }
 
 // De-risking guide
-.first_page > h1 {
+.first_page>h1 {
   @include u-font('sans', '3xl');
 }
 
-.first_page > h2 {
+.first_page>h2 {
   @include u-font('sans', '2xl');
   border-top: 1px solid color('primary-dark');
   padding-top: units(1.5);
@@ -158,7 +170,7 @@ h2.heading-md {
 /* checklists and key questions */
 .guide-checklist,
 .key-questions {
-  @include u-font('sans','md');
+  @include u-font('sans', 'md');
   color: color('white');
   padding: units(1);
 }
@@ -171,30 +183,30 @@ h2.heading-md {
   background-color: color('primary-darker');
 }
 
-.guide-checklist + ul,
-.key-questions + ul {
+.guide-checklist+ul,
+.key-questions+ul {
   background-color: color('blue-5');
-  margin-top:0;
+  margin-top: 0;
   padding-top: units(1);
   padding-right: units(2);
   padding-bottom: units(1);
 }
 
-.guide-checklist + ul li,
-.key-questions + ul li {
+.guide-checklist+ul li,
+.key-questions+ul li {
   margin-bottom: units(1);
 }
 
-.guide-checklist + ul,
-.guide-checklist + ul ul,
-.guide-checklist--single + ul {
+.guide-checklist+ul,
+.guide-checklist+ul ul,
+.guide-checklist--single+ul {
   list-style: none;
   margin-left: 0;
   padding-left: units(1);
 }
 
-.guide-checklist + ul li,
-.guide-checklist--single + ul li {
+.guide-checklist+ul li,
+.guide-checklist--single+ul li {
   padding-left: $bullet-spacing;
   text-indent: (-1 * $bullet-spacing);
 
@@ -256,9 +268,9 @@ h2.heading-md {
   }
 }
 
-#packaging-style {
+.packaging-style {
   color: #046b99;
-  font-size: 1.2rem; 
+  font-size: 1.2rem;
   font-weight: 500;
   margin-bottom: 0.5rem;
   margin-left: -5%;
@@ -266,12 +278,12 @@ h2.heading-md {
   text-decoration: none;
 }
 
-#packaging-style:hover {
+.packaging-style:hover {
   background-color: #f1f1f1;
 }
 
 .packaging-list-style {
-  list-style: none; 
+  list-style: none;
 }
 
 .tooltip {

--- a/assets/_common/styles/custom-styles.scss
+++ b/assets/_common/styles/custom-styles.scss
@@ -128,11 +128,11 @@ a.usa-button--accent {
 }
 
 // De-risking guide
-.first_page>h1 {
+.first_page > h1 {
   @include u-font('sans', '3xl');
 }
 
-.first_page>h2 {
+.first_page > h2 {
   @include u-font('sans', '2xl');
   border-top: 1px solid color('primary-dark');
   padding-top: units(1.5);
@@ -183,8 +183,8 @@ h2.heading-md {
   background-color: color('primary-darker');
 }
 
-.guide-checklist+ul,
-.key-questions+ul {
+.guide-checklist + ul,
+.key-questions + ul {
   background-color: color('blue-5');
   margin-top: 0;
   padding-top: units(1);
@@ -192,21 +192,21 @@ h2.heading-md {
   padding-bottom: units(1);
 }
 
-.guide-checklist+ul li,
-.key-questions+ul li {
+.guide-checklist + ul li,
+.key-questions + ul li {
   margin-bottom: units(1);
 }
 
-.guide-checklist+ul,
-.guide-checklist+ul ul,
-.guide-checklist--single+ul {
+.guide-checklist + ul,
+.guide-checklist + ul ul,
+.guide-checklist--single + ul {
   list-style: none;
   margin-left: 0;
   padding-left: units(1);
 }
 
-.guide-checklist+ul li,
-.guide-checklist--single+ul li {
+.guide-checklist + ul li,
+.guide-checklist--single + ul li {
   padding-left: $bullet-spacing;
   text-indent: (-1 * $bullet-spacing);
 

--- a/content/resources/packaging/gitHub-repo-template-guide.md
+++ b/content/resources/packaging/gitHub-repo-template-guide.md
@@ -69,8 +69,6 @@ app/
  └── rollup.config.mjs
 ```
 
-### 
-
 ### **Phase 2: Template Preparation**
 
 #### **Step 4: Create Template Documentation**

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -26,7 +26,7 @@ subnav:
 <ul class="packaging-list-style">
   {% for guide in subnav %}
     <li>
-        <a href="{{ guide.href | url }}" id="packaging-style">
+        <a class="packaging-style" href="{{ guide.href | url }}" >
           {{ guide.text }}
         </a>
     </li>


### PR DESCRIPTION
## Workflows: Fix pa11y errors

## Problem

After fixing the pa11y test in our PR checks job, it identified errors on the following pages. This PR fixes these errors
```
 > http://localhost:8080/growing/reading-list/ - 8 errors
 > http://localhost:8080/outbound/508-checklist/ - 20 errors
 > http://localhost:8080/outbound/archiving-repositories/ - 50 errors
> http://localhost:8080/outbound/exemption-criteria/ - 26 errors
> http://localhost:8080/resources/packaging/github-repo-template-guide/ - 27 errors
```


## Solution

- Packaging: Duplicate id name `packaging-style` in 3 `<a>` components so updated to be a class instead
- Guides that use checkbox list: Configured `markdownItTaskLists` to wrap a `<label>` around all checkbox options
- Github Repo Template Guide: Fix file name typo and removed empty heading

Rest of changes are linting updates

## Result

pa11y scan test now passes as seen below

## Test Plan

pa11y scan test now passes as seen below