### PR TITLE
Guides: Add text pointing to repository templates

### DIFF
--- a/content/resources/beginner-guide-github-repos.md
+++ b/content/resources/beginner-guide-github-repos.md
@@ -131,4 +131,6 @@ Each **maturity model tier** requires specific file and documentation, such as p
 
  To get started, use the tools provided in [repo-scaffolder](https://dsacms.github.io/repo-scaffolder/#repo-to-project) site to create a new project from a template.
 
- Additional guidance is available here, [repo-scaffolder](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#2-set-up-your-repository) GitHub - Learn how to generate a new repository using the correct tier.
+Repository Templates are found here:
+- [github.com/DSACMS](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#2-set-up-your-repository)
+- [github.cms.gov](https://github.cms.gov/ospo?q=&type=template&language=&sort=name)

--- a/content/resources/github-management-policy.md
+++ b/content/resources/github-management-policy.md
@@ -106,7 +106,6 @@ Requests to create and grant access to teams & repositories must be filed under 
 ##### Step 1: Creating a Team with Project Maintainers - Maintainers Team
 
 Project maintainers will be placed in their own separate team and serve as the main point of contact for coordinating team & repository management with the OSPO.
-Project maintainers will be placed in their own separate team and serve as the main point of contact for coordinating team & repository management with the OSPO.
 
 Information required:
 
@@ -150,9 +149,13 @@ Information required:
 
 #### Request a new repo to be created
 
-If you are looking to migrate an existing repository hosted in a different organization into a new repository under DSACMS, the new repository will be created as private by default. In order for your repository to be released as public, please follow our [outbound review checklist](https://github.com/DSACMS/ospo-guide/blob/main/outbound/OUTBOUND_CHECKLISTS.md) for your project’s maturity tier.
+If you are looking to migrate an existing repository hosted in a different organization into a new repository under DSACMS, the new repository will be created as private by default. In order for your repository to be released as public, please follow our [outbound review checklist](https://dsacms.github.io/ospo-guide/outbound/outbound-checklists/) for your project’s maturity tier.
 
-If you are looking to create a completely new repository, your repository can be created as private or public. Based on the maturity model tier selected, a collection of [markdown templates](https://github.com/DSACMS/ospo-guide/blob/main/outbound/REPOSITORY_TEMPLATES_AND_LINTERS.md) will be included as part of our repository hygiene standards. GitHub security features such as Dependabot and secret scanning will be enabled.
+If you are looking to create a completely new repository, your repository can be created as private or public. Based on the maturity model tier selected, a collection of [markdown templates](https://dsacms.github.io/ospo-guide/outbound/repository-templates-and-linters/) will be included as part of our repository hygiene standards. GitHub security features such as Dependabot and secret scanning will be enabled.
+
+For more information on repository creation using templates, visit:
+- [Creating GitHub repositories guide](https://dsacms.github.io/ospo-guide/resources/beginner-guide-github-repos/)
+- [repo-scaffolder](https://dsacms.github.io/repo-scaffolder/)
 
 Information required:
 


### PR DESCRIPTION
## Guides: Add text pointing to repository templates

## Problem

We would like to add links pointing to the new internal templates

## Solution

- Added a new section in `beginner-guide-github-repos.md` pointing to repository templates offered in public and internal GitHub
- Added new section pointing to various resources on repository creation in  in `github-management-policy.md`
- Fixed broken links in `github-management-policy.md`
- Removed dupe text in `github-management-policy.md`