### PR TITLE
Tools Page: Update projectURL to homepageURL in tool-card

### DIFF
--- a/_includes/tools/tool-card.html
+++ b/_includes/tools/tool-card.html
@@ -14,8 +14,8 @@
       <span class="tool-tag">{{ tag }}</span>
       {% endfor %}
     </div>
-    {% if tool.projectURL != "" %}
-    <a href="{{ tool.projectURL }}" target="_blank" class="btn">Open tool</a>
+    {% if tool.homepageURL != "" %}
+    <a href="{{ tool.homepageURL }}" target="_blank" class="btn">Open tool</a>
     {% endif %}
     <a href="{{ tool.repositoryURL }}" target="_blank" class="btn btn-outline">View on GitHub</a>
   </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Tools Page: Update projectURL to homepageURL in tool-card

## Problem

Currently, the "Open Tool" button in the tool card is broken. This is because it used a retired code.json field that is not in the latest schema.

## Solution

- Update `projectURL` to `homepageURL` in tool-card

## Result

If a project has `homepageURL`, the "Open Tool" button is displayed. When the user clicks on the "Open Tool" button, it takes them to the landing page of the tool