### PR TITLE
Guides: Add/update description front matter to guides for meta descriptions

### DIFF
--- a/content/about/functional-statement.md
+++ b/content/about/functional-statement.md
@@ -1,5 +1,6 @@
 ---
 title: CMS OSPO Functional Statement
+description: Functional Statement of the CMS Open Source Program Office
 permalink: /about/functional-statement/
 layout: layouts/page
 tags: ospo

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,6 +1,6 @@
 ---
 title: About the CMS Open Source Program Office
-description: 'Learn more about open source at CMS'
+description: Learn more about Open Source at CMS
 permalink: /about/
 layout: layouts/page
 tags: ospo

--- a/content/about/tra.md
+++ b/content/about/tra.md
@@ -1,6 +1,6 @@
 ---
 title: CMS' Technical Reference Architecture (TRA)
-description: 'CMS Technical Reference Architecture (TRA)'
+description: The CMS Technical Reference Architecture articulates the technical architecture of all Centers for Medicare & Medicaid Services (CMS) processing environments
 permalink: /about/tra/
 layout: layouts/page
 section: about

--- a/content/growing/508-training.md
+++ b/content/growing/508-training.md
@@ -1,6 +1,6 @@
 ---
 title: 508 Training Federal Resources
-description: 'Growing'
+description: Resources and training on Section 508
 permalink: /growing/508-training/
 layout: layouts/page
 section: growing

--- a/content/growing/early-career-talent-pipeline.md
+++ b/content/growing/early-career-talent-pipeline.md
@@ -1,6 +1,6 @@
 ---
 title: Early Career Talent Pipeline
-description: 'Information on CMS OSPO Early Career Talent Pipeline'
+description: Information on CMS OSPO Early Career Talent Pipeline
 permalink: /growing/early-career-talent-pipeline/
 layout: layouts/page
 section: growing

--- a/content/growing/how-to-work-at-dsac.md
+++ b/content/growing/how-to-work-at-dsac.md
@@ -1,6 +1,6 @@
 ---
 title: How to work at DSAC
-description: 'Guides to working at DSAC'
+description: Guides to working at the Digital Service at CMS
 permalink: /growing/how-to-work-at-dsac/
 layout: layouts/page
 section: growing

--- a/content/growing/index.md
+++ b/content/growing/index.md
@@ -1,6 +1,6 @@
 ---
 title: Growing
-description: 'Growing'
+description: Learn about initiatives to grow OSPOs (conferences & speaking, talent pipelines) and federal policies that guide our work
 permalink: /growing/
 layout: layouts/page
 tags: ospo

--- a/content/growing/mentorship.md
+++ b/content/growing/mentorship.md
@@ -1,6 +1,6 @@
 ---
 title: Mentorship
-description: 'General approach of mentorship and support of the CMS OSPO'
+description: General approach of mentorship and support of the CMS OSPO
 permalink: /growing/mentorship/
 layout: layouts/page
 section: growing

--- a/content/growing/ospo-mindmap.md
+++ b/content/growing/ospo-mindmap.md
@@ -1,6 +1,6 @@
 ---
 title: OSPO Mind Map
-description: 'OSPO Mind map'
+description: OSPO Mindmap
 permalink: /growing/ospo-mindmap/
 layout: layouts/page
 section: growing

--- a/content/growing/plain-language.md
+++ b/content/growing/plain-language.md
@@ -1,6 +1,6 @@
 ---
 title: Plain Language Federal Resources
-description: 'Growing'
+description: Resources and training on Plain Language
 permalink: /growing/plain-language/
 layout: layouts/page
 section: growing

--- a/content/growing/pra.md
+++ b/content/growing/pra.md
@@ -1,6 +1,6 @@
 ---
 title: Paperwork Reduction Act Federal Resources
-description: 'Growing'
+description: Resources and training on the Paperwork Reduction Act
 permalink: /growing/pra/
 layout: layouts/page
 section: growing

--- a/content/growing/reading-list.md
+++ b/content/growing/reading-list.md
@@ -1,6 +1,6 @@
 ---
 title: OSPO Reading List
-description: 'List of readings by the CMS OSPO'
+description: List of readings curated by the CMS OSPO
 permalink: /growing/reading-list/
 layout: layouts/page
 section: growing

--- a/content/growing/recommended-conferences.md
+++ b/content/growing/recommended-conferences.md
@@ -1,6 +1,6 @@
 ---
 title: Recommended Conferences
-description: 'List of recommended conferences by the CMS OSPO'
+description: List of conferences recommended by the CMS OSPO
 permalink: /growing/recommended-conferences/
 layout: layouts/page
 section: growing

--- a/content/growing/retros.md
+++ b/content/growing/retros.md
@@ -1,6 +1,6 @@
 ---
 title: Retrospectives
-description: 'Retro models used in the CMS OSPO'
+description: Retro models used in the CMS OSPO
 permalink: /growing/retros/
 layout: layouts/page
 section: growing

--- a/content/growing/want-to-start-an-ospo.md
+++ b/content/growing/want-to-start-an-ospo.md
@@ -1,6 +1,6 @@
 ---
 title: Want to Start an OSPO
-description: 'Guide on starting an OSPO'
+description: Guide on starting an OSPO
 permalink: /growing/want-to-start-an-ospo/
 layout: layouts/page
 section: growing

--- a/content/inbound/acceptable-licenses.md
+++ b/content/inbound/acceptable-licenses.md
@@ -1,6 +1,6 @@
 ---
 title: Acceptable Licenses
-description: 'Acceptable Licenses'
+description: Acceptable licenses for use in CMS projects
 permalink: /inbound/acceptable-licenses/
 layout: layouts/page
 section: inbound

--- a/content/inbound/inbound-review-checklist.md
+++ b/content/inbound/inbound-review-checklist.md
@@ -1,6 +1,6 @@
 ---
 title: Inbound Review Checklist
-description: 'The review process to approve open source software to be used in the agency.'
+description: The review process to approve open source software to be used in CMS
 permalink: /inbound/inbound-review-checklist/
 layout: layouts/page
 section: inbound

--- a/content/inbound/index.md
+++ b/content/inbound/index.md
@@ -1,6 +1,6 @@
 ---
 title: Inbound
-description: 'Inbounding'
+description: Learn about managing open-source dependencies by enforcing compliance, mitigating security risks, and aligning with organizational policies to ensure responsible OSS usage while maximizing its benefits.
 permalink: /inbound/
 layout: layouts/page
 tags: ospo

--- a/content/outbound/508-checklist.md
+++ b/content/outbound/508-checklist.md
@@ -1,6 +1,6 @@
 ---
 title: Digital Presentation 508 Checklist
-description: 'Checklist to 508 a digital presentation'
+description: Checklist to 508 a digital presentation
 permalink: /outbound/508-checklist/
 layout: layouts/page
 section: outbound

--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -1,6 +1,6 @@
 ---
 title: Archiving Repositories
-description: 'Guidance on archiving repositories'
+description: Guidance on archiving repositories
 permalink: /outbound/archiving-repositories/
 layout: layouts/page
 section: outbound

--- a/content/outbound/bulk_extractor.md
+++ b/content/outbound/bulk_extractor.md
@@ -1,6 +1,6 @@
 ---
 title: Using Bulk_extractor
-description: 'Guide on using Bulk_Extractor for secret scanning'
+description: Guide on using Bulk_Extractor for secret scanning
 permalink: /outbound/bulk_extractor/
 layout: layouts/page
 section: outbound

--- a/content/outbound/exemption-criteria.md
+++ b/content/outbound/exemption-criteria.md
@@ -1,6 +1,6 @@
 ---
 title: Risk Acceptance and Exemption Criteria of Open Sourcing
-description: 'Guidance on risk acceptance and exeption criteria for your repository'
+description: Guidance on risk acceptance and exemption criteria for your repository
 permalink: /outbound/exemption-criteria/
 layout: layouts/page
 section: outbound

--- a/content/outbound/how-to-grow-your-open-source-project.md
+++ b/content/outbound/how-to-grow-your-open-source-project.md
@@ -1,6 +1,6 @@
 ---
 title: How to start and grow your open source project
-description: 'Guidance on growing your open source project'
+description: Guidance on starting and growing an open source project
 permalink: /outbound/how-to-grow-your-open-source-project/
 layout: layouts/page
 section: outbound

--- a/content/outbound/index.md
+++ b/content/outbound/index.md
@@ -1,6 +1,6 @@
 ---
 title: Outbound
-description: 'Outbounding'
+description: Learn about reviewing internal projects to release as open source and best practices to managing repositories and their communities
 permalink: /outbound/
 layout: layouts/page
 tags: ospo

--- a/content/outbound/maturity-models.md
+++ b/content/outbound/maturity-models.md
@@ -1,6 +1,6 @@
 ---
 title: Maturity Models
-description: 'CMS OSPO Maturity Model Framework'
+description: CMS OSPO Maturity Model Framework
 permalink: /outbound/maturity-models/
 layout: layouts/page
 section: outbound

--- a/content/outbound/outbound-checklists.md
+++ b/content/outbound/outbound-checklists.md
@@ -1,6 +1,6 @@
 ---
 title: Outbound Checklists
-description: 'CMS OSPO Outbound Review Checklists'
+description: CMS OSPO Outbound Review Checklists
 permalink: /outbound/outbound-checklists/
 layout: layouts/page
 section: outbound

--- a/content/outbound/release-guidelines.md
+++ b/content/outbound/release-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: Release Guidelines
-description: 'Document on release guidelines'
+description: Document on release guidelines
 permalink: /outbound/release-guidelines/
 layout: layouts/page
 section: outbound

--- a/content/outbound/repository-metadata.md
+++ b/content/outbound/repository-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Repository Metadata
-description: 'Collecting repository metadata using code.json'
+description: Collecting repository metadata using code.json
 permalink: /outbound/repository-metadata/
 layout: layouts/page
 section: outbound

--- a/content/outbound/repository-templates-and-linters.md
+++ b/content/outbound/repository-templates-and-linters.md
@@ -1,6 +1,6 @@
 ---
 title: Repository Templates & Linters
-description: 'Guidance on CMS OSPO Repository Templates & Linters'
+description: Guidance on CMS OSPO Repository Templates & Linters
 permalink: /outbound/repository-templates-and-linters/
 layout: layouts/page
 section: outbound

--- a/content/resources/beginner-guide-github-repos.md
+++ b/content/resources/beginner-guide-github-repos.md
@@ -1,6 +1,6 @@
 ---
 title: Beginner Guide to Creating GitHub Repos
-description: 'A glossary of definitions for frequently asked words and phrases'
+description: A glossary of definitions for frequently asked words and phrases
 permalink: /resources/beginner-guide-github-repos/
 layout: layouts/page
 section: resources

--- a/content/resources/cybersecurity.md
+++ b/content/resources/cybersecurity.md
@@ -1,6 +1,6 @@
 ---
 title: Cybersecurity at CMS
-description: 'Cybersecurity at CMS resources'
+description: Resources for Cybersecurity at CMS
 permalink: /resources/cybersecurity/
 layout: layouts/page
 section: resources

--- a/content/resources/github-management-policy.md
+++ b/content/resources/github-management-policy.md
@@ -1,6 +1,6 @@
 ---
 title: GitHub Management Policy
-description: 'Managing organizations and repositories using GitHub'
+description: Managing organizations and repositories using GitHub
 permalink: /resources/github-management-policy/
 layout: layouts/page
 section: resources

--- a/content/resources/github101.md
+++ b/content/resources/github101.md
@@ -1,6 +1,6 @@
 ---
 title: GitHub 101
-description: 'Basic Git Terminology and GitHub Workflow overview'
+description: Basic Git Terminology and GitHub Workflow overview
 permalink: /resources/github101/
 layout: layouts/page
 section: resources

--- a/content/resources/glossary.md
+++ b/content/resources/glossary.md
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: 'A glossary of definitions for frequently asked words and phrases'
+description: A glossary of definitions for frequently asked words and phrases
 permalink: /resources/glossary/
 layout: layouts/page
 section: resources

--- a/content/resources/index.md
+++ b/content/resources/index.md
@@ -1,6 +1,6 @@
 ---
 title: Resources
-description: 'Resources'
+description: Find resources on developer training (GitHub), case studies, user research, and more.
 permalink: /resources/
 layout: layouts/page
 tags: ospo

--- a/content/resources/packaging/exporting-python-projects.md
+++ b/content/resources/packaging/exporting-python-projects.md
@@ -1,6 +1,6 @@
 ---
 title: Packaging Python Projects
-description: 'Guidelines for publishing python projects as packages'
+description: Guidelines for publishing python projects as packages
 permalink: /resources/packaging/exporting-python-projects/
 layout: layouts/page
 section: resources

--- a/content/resources/packaging/git-submodule-guide.md
+++ b/content/resources/packaging/git-submodule-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Git Submodules
-description: 'Guidelines for Git Submodules'
+description: Guidelines for Git Submodules
 permalink: /resources/packaging/git-submodule-guide/
 layout: layouts/page
 section: resources

--- a/content/resources/packaging/gitHub-repo-template-guide.md
+++ b/content/resources/packaging/gitHub-repo-template-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Creating GitHub Repo Templates
-description: 'Guidelines for publishing JavaScript projects as packages'
+description: Guidelines for publishing JavaScript projects as packages
 permalink: /resources/packaging/github-repo-template-guide/
 layout: layouts/page
 section: resources

--- a/content/resources/packaging/index.md
+++ b/content/resources/packaging/index.md
@@ -1,6 +1,6 @@
 ---
 title: Packaging Guides
-description: 'Packaging Guides'
+description: A set of guides on creating software packages
 permalink: /resources/packaging/
 layout: layouts/page
 section: resources

--- a/content/resources/user-guide-template.md
+++ b/content/resources/user-guide-template.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide Template
-description: 'DSAC User Guide Template'
+description: DSAC User Guide Template
 permalink: /resources/user-guide-template/
 layout: layouts/page
 section: resources

--- a/content/resources/user-stories-101.md
+++ b/content/resources/user-stories-101.md
@@ -1,6 +1,6 @@
 ---
 title: User Story Writing 101
-description: 'Intro to writing user stories'
+description: Guide on writing user stories
 permalink: /resources/user-stories-101/
 layout: layouts/page
 section: resources

--- a/content/resources/xz-supply-chain-attack.md
+++ b/content/resources/xz-supply-chain-attack.md
@@ -1,6 +1,6 @@
 ---
 title: CMS OSPO Report - CVE-2024-3094 Backdoor in XZ
-description: 'CMS OSPO Report on XZ Supply Chain Attack'
+description: CMS OSPO Report on XZ Supply Chain Attack
 permalink: /resources/xz-supply-chain-attack/
 layout: layouts/page
 section: resources


### PR DESCRIPTION
## Guides: Add/update description front matter to guides for meta descriptions

## Problem

As part of search, we would like to add meta descriptions to all of our guides. Currently, some of our guides do not have descriptions or need a description refresh.

## Solution

- Add/update description front matter to all guides

## Result

All guides have description front matter, thus will have meta descriptions!

## Test Plan
`npm run dev`