### PR TITLE
Engineering Handbook: Add Github Profile section

### DIFF
--- a/content/growing/how-to-work-at-dsac.md
+++ b/content/growing/how-to-work-at-dsac.md
@@ -29,6 +29,19 @@ To set up your local system and obtain access to all tools and environments, fol
 
 ## Development Practices
 
+### GitHub Profile
+When working at DSAC, you have two primary options for your GitHub account:
+1. Use your existing GitHub profile
+  - Maintains your contribution history and profile
+  - Your personal and government work will be associated in the same profile
+2. Create a new GitHub account for DSAC and government-specific work
+  - Dedicated identity for CMS & government specific work
+- Clear separation between personal and professional work
+
+Be sure to configure the following for the account of usage:
+- Enable 2FA
+- Set your commit email to your CMS email address for government work
+
 ### CMS GitHubs
 
 There are various GitHub instances and organizations actively used at CMS.

--- a/content/growing/how-to-work-at-dsac.md
+++ b/content/growing/how-to-work-at-dsac.md
@@ -42,6 +42,8 @@ Be sure to configure the following for the account of usage:
 - Enable 2FA
 - Set your commit email to your CMS email address for government work
 
+For instructions on setting up your GitHub profile to access CMS organizations, visit the [DSAC Onboarding Document](https://docs.google.com/document/d/1Yf2A9vU0yDLxq6uhOFcWVdksrad-B0NrVUlT2RgqTUc/edit?tab=t.0#heading=h.6zxrn2zh9vt2).
+
 ### CMS GitHubs
 
 There are various GitHub instances and organizations actively used at CMS.


### PR DESCRIPTION
## Engineering Handbook: Add Github Profile section

## Problem

We would like to add guidance on Github Profiles since this is a common question we receive from engineers

## Solution

- Add a new section about GitHub Profiles providing guidance on whether to use existing profile or create a new account for DSAC work

## Result

With the new GitHub profile section, users have guidance on which GitHub account to use for DSAC work

## Test Plan

All checks pass