### PR TITLE
Archiving repositories guide: Add section on repo-sunsetter and link checklist

### DIFF
--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -108,9 +108,12 @@ Repository Pull Requests serve as a type of record of the decision making proces
 - [ ] Review releases and tags (if applicable, Maturity Model Tier3+)
 
 ## repo-sunsetter
-repo-sunsetter is a GitHub Action developed by the OSPO to prepare repositories for archival. It implements the work described above by filing an issue with the archival review checklist as well as automating README documentation & metadata updates.
+repo-sunsetter is a repository-level GitHub Action developed by the OSPO to prepare repositories for archival. It implements the work described above by:
+1. Adds an archival notice to the README.md to inform users about the state of the repository
+2. Updates project metadata by marking project as archived in code.json
+3. Files an issue containing the archival checklist based on the repository's maturity model tier.
 
-For more information on using this action, visit the [repo-sunsetter repository](https://github.com/DSACMS/repo-sunsetter).
+For more information on using this action for your team's / organization's repository, visit the [repo-sunsetter repository](https://github.com/DSACMS/repo-sunsetter).
 
 ## Archiving a repository on DSACMS GitHub
 

--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -27,7 +27,10 @@ _Based on TODOgroup's guide: <br /> [https://github.com/todogroup/guides/blob/ma
 - Project performance metrics (e.g. participation, usage, adoption, updates) are declining based on your latest user data
 - Maintenance status has changed (e.g. code is no longer being patched or updated by the community to resolve vulnerabilities)
 
-# Repository Archival Checklist
+# Repository Archival Checklists
+To prepare a repository for archival, complete the tasks below to perform a thorough review of the repository.
+
+_A complete list of all tasks described below are complied in checklists found [here](https://github.com/DSACMS/repo-sunsetter/tree/main/checklists)._
 
 ## For all tiers 
 
@@ -46,7 +49,7 @@ Enabling `archived` mode in the [automated-codejson-generator GitHub Action](htt
 Repository Documentation can provide explicit statements about the status of a project or community. Communicating clearly, whether the project is active or inactive, is important.
 
 #### Update Repository Documentation
-- [ ] Clearly state at the top the README that the project has been deprecated and will no longer be updated. If possible, suggest alternate projects that provide similar functionality.
+- [ ] Clearly state at the top of the README that the project has been deprecated and will no longer be updated. If possible, suggest alternate projects that provide similar functionality.
   - Sample Text:
     > "This project is now archived and no longer actively maintained. It has been archived to retain its contents for reference. Feel free to explore and fork the repository, but please note that updates or support will not be provided."
 
@@ -63,7 +66,9 @@ Repository Issues serve as a type of record of the decision making processes of 
 - [ ] Review committer access
 
 #### Perform a lightweight security review
-- [ ] Review for secrets, keys, PII
+- [ ] Review repository for secrets and keys
+- [ ] Check for any Personal Identifiable Information (PII)
+- Remove or redact any sensitive information found
 
 ### Other
 - [ ] Delete inactive branches
@@ -101,6 +106,11 @@ Repository Pull Requests serve as a type of record of the decision making proces
 - [ ] Resolve code scanning and security alerts (e.g. Dependabot, CodeQL)
 - [ ] Ensure CHANGELOG.md outlines completed work and the project's final state
 - [ ] Review releases and tags (if applicable, Maturity Model Tier3+)
+
+## repo-sunsetter
+repo-sunsetter is a GitHub Action developed by the OSPO to prepare repositories for archival. It implements the work described above by filing an issue with the archival review checklist as well as automating README documentation & metadata updates.
+
+For more information on using this action, visit the [repo-sunsetter repository](https://github.com/DSACMS/repo-sunsetter).
 
 ## Archiving a repository on DSACMS GitHub
 

--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -68,7 +68,7 @@ Repository Issues serve as a type of record of the decision making processes of 
 #### Perform a lightweight security review
 - [ ] Review repository for secrets and keys
 - [ ] Check for any Personal Identifiable Information (PII)
-- Remove or redact any sensitive information found
+- [ ] Remove or redact any sensitive information found
 
 ### Other
 - [ ] Delete inactive branches

--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -138,3 +138,6 @@ Submit a request to the [CMS Web Help Service Desk:](https://jira.cms.gov/servic
 
 Submit a request to the [CMS Enterprise Agile Tools Service Desk:](https://jiraent.cms.gov/servicedesk/customer/portal/4)
 [https://jiraent.cms.gov/servicedesk/customer/portal/4/create/183](https://jiraent.cms.gov/servicedesk/customer/portal/4/create/183)
+
+## Resources
+[Practitioner Guide: Getting Started with Sunsetting an Open Source Project by CHAOSS](https://chaoss.community/practitioner-guide-sunset/)


### PR DESCRIPTION
## Archiving repositories guide: Add section on repo-sunsetter and link checklist

## Problem

We have made significant updates on the repository life cycle's path of archival that we would like to share in our guide.

## Solution

- Added new section on `repo-sunsetter` and what it is.
- Add missing tasks in the lightweight security review
- Added a link that points to checklist templates
- Fix typos
- Add link to CHAOSS practitioner guide

## Result

The Archiving repositories guide is fully up-to-date!

## Test Plan

All checks pass