### PR TITLE
Archival Guide: Update repo-sunsetter link

### DIFF
--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -113,7 +113,7 @@ repo-sunsetter is a repository-level GitHub Action developed by the OSPO to prep
 2. Updates project metadata by marking project as archived in code.json
 3. Files an issue containing the archival checklist based on the repository's maturity model tier.
 
-For more information on using this action for your team's / organization's repository, visit the [repo-sunsetter repository](https://github.com/DSACMS/repo-sunsetter).
+For more information on using this action for your team's / organization's repository, visit the [repo-sunsetter GitHub Actions Marketplace page](https://github.com/marketplace/actions/repo-sunsetter).
 
 ## Archiving a repository on DSACMS GitHub
 


### PR DESCRIPTION
## Archival Guide: Update repo-sunsetter link

## Problem

Now that repo-sunsetter is published in the GitHub Actions Marketplace, we would like to add this link to the repo-sunsetter section of the archival guide!

## Solution

- Add https://github.com/marketplace/actions/repo-sunsetter