### PR TITLE
Growing: Editing name of Coding it Forward fellowship

### DIFF
--- a/content/growing/early-career-talent-pipeline.md
+++ b/content/growing/early-career-talent-pipeline.md
@@ -24,7 +24,7 @@ The Digital Service at the Centers for Medicare and Medicaid Services (CMS) is c
 
 {% image_with_class "assets/resources/img/early-career-talent-pipeline/usdc.png" "" "United States Digital Corps logo" %}
 
-- [Civic Digital Fellowship at Coding it Forward](https://www.codingitforward.com) - Paid 10 week summer internship program for currently enrolled undergrad, grad, bootcamp students or recent graduates.
+- [Coding it Forward Fellowship](https://www.codingitforward.com) - Paid 10 week summer internship program for currently enrolled undergrad, grad, bootcamp students or recent graduates.
 
 {% image_with_class "assets/resources/img/early-career-talent-pipeline/coding_it_forward.png" "" "Coding It Forward logo" %}
 


### PR DESCRIPTION
## Growing: Editing name of Coding it Forward fellowship

## Problem

We would like to update the name of the CIF fellowship.

## Solution

- Updated name from `Civic Digital Fellowship at Coding it Forward` to `Coding It Forward Fellowship`

## Result

CIF Fellowship is now up-to-date in our Early Career Talent Pipeline guide

## Test Plan
PR checks all passed. 
Successfully runs locally