### PR TITLE
[DRAFT] Outbound: Create new Generative AI Usage policy

### DIFF
--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -1,0 +1,56 @@
+---
+title: Gen AI Usage Guidance in Software Development
+description: Guidance for using Generative AI when developing tools at the CMS OSPO
+permalink: /outbound/gen-ai-policy/
+layout: layouts/page
+section: outbound
+tags: ospo
+eleventyNavigation:
+  parent: ospo-outbound
+  key: ospo-outbound-genaipolicy
+  order: 13
+  title: Gen AI Usage Guidance in Software Development
+sidenav: true
+sticky_sidenav: true
+---
+
+## DSACMS Gen AI Policy
+- Explicitly state where AI was used in PRs
+- Never ship AI code you can’t explain line by line to a developer
+- If the human effort put in a PR, e.g. writing LLM prompts, is less than the effort we would need to put to review it, please don't submit the PR. Think of it this way: we can already write LLM prompts or run automated tools ourselves, and that would be faster and more secure than reviewing external PRs.
+
+## Pull Request Guidelines
+
+## Example 1: Repositories that allow AI-generated contributions
+
+We don’t accept PRs that:
+- Don’t directly address an existing issue
+- Touch more than X files at a time
+- contain more than Y commits
+- Change core system files such as …
+- Are untested / don’t pass our test suite / don’t pass our linters / don’t follow styleguide
+
+- [ ] Generated AI was used in this contribution
+
+If checked, please provide an explanation on how AI was used in the development of this pull request:
+
+## Example 2: Repositories not accepting AI-generated pull requests
+We don’t accept PRs that:
+- Don’t directly address an existing issue
+- Touch more than X files at a time
+- contain more than Y commits
+- Change core system files such as …
+- Are untested / don’t pass our test suite / don’t pass our linters / don’t follow styleguide
+- Are entirely AI generated
+
+We accept feedback in the form of issues for the following: bug reports, feature requests
+
+**Reducing the risk of Extractive Contributions**
+- Limiting PRs/contributions to existing tickets reduces the risk of ‘roadmap drift’ where contributions take away limited time/energy/attention from the established priorities of the project.
+- Limiting files and commits and file surface reduces the ‘splash radius’ and review time needed from a human.
+- Test suite, linters, styleguides ensure that contributions meet our requirements, do not introduce breaking changes, and keep a consistent voice/brand/culture.
+- These are built to reduce extractive contributions from HUMANS first, and also limits extractive AI contributions as a side-effect.
+- Turns reviews from a high-effort one-off evaluation, into a checklist. Checklists are made for Humans. They create structured spaces for intentional, participatory transition, that reduce cognitive and actual burden and effort.
+- Machine-readable metadata can be derived from metrics, but human judgement prevails, and communication is human-readable, by and for people.
+Templates for responding to extractive contributions can be copy-pasted and automated to encourage contributions that follow the guidelines, without the maintainers needing to custom-respond to every PR.
+- It’s not humans versus machines, it’s clarity v.s. ambiguity.

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -34,7 +34,7 @@ If AI is used in your work, explicitly state where and how it was used in your p
 ### Human in the Loop
 Using mentioned above, using AI does not change who's responsible for the code you submit. A person remains accountable for their every contribution and AI does not act on the project's behalf unsupervised.
 
-- Unacceptable: Using external AI tooling *(bots, agents)* to directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub.
+- Not Recommended: Using external AI tooling *(bots, agents)* to directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub.
 
 ### Responsible Development and Code Quality
 Using AI does not lower the bar and quality of your code contributions.
@@ -42,7 +42,7 @@ Using AI does not lower the bar and quality of your code contributions.
 - Unacceptable: Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
 - Unacceptable: Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
 
-### Review
+### Human Review and Validation
 The effort you put into a contribution should meet or exceed the effort it takes to review it. We want to reduce the number of extractive contributions coming in, since this takes valuable time and effort away from doing our work.
 
 - Unacceptable: Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
@@ -59,11 +59,17 @@ We don’t accept PRs that:
 - Touch more than X files at a time
 - Contain more than Y commits
 - Change core system files such as …
-- Are untested / don’t pass our test suite / don’t pass our linters / don’t follow styleguide
+- Are untested / don’t pass our test suite / don’t pass our linters / don’t follow style guide
 
 - [ ] Generated AI was used in this contribution
 
 If checked, please provide an explanation on how AI was used in the development of this pull request:
+
+- Description: _Include a high level description of Gen AI utilization_
+- Type of assistance: _Code generation, documentation, debugging, testing, refactoring, etc._
+- Scope of usage: _Which files, functions, or sections were AI-assisted_
+- Tool(s) used: _Name of the AI system(s) employed (e.g., GitHub Copilot, ChatGPT, etc.)_
+- Level of modification: _Whether AI-generated content was used as-is, modified, or used as inspiration_
 
 ### Example 2: Repositories not accepting AI-generated pull requests
 We don’t accept PRs that:
@@ -71,10 +77,10 @@ We don’t accept PRs that:
 - Touch more than X files at a time
 - Contain more than Y commits
 - Change core system files such as …
-- Are untested / don’t pass our test suite / don’t pass our linters / don’t follow styleguide
+- Are untested / don’t pass our test suite / don’t pass our linters / don’t follow style guide
 - Are entirely AI generated
 
-We accept feedback in the form of issues for the following: bug reports, feature requests
+We only accept feedback in the form of issues for the following: bug reports, feature requests
 
 ## Reducing the Risk of Extractive Contributions
 - Limiting PRs/contributions to existing tickets reduces the risk of "roadmap drift", where contributions take away limited time/energy/attention from the established priorities of the project.
@@ -85,3 +91,7 @@ We accept feedback in the form of issues for the following: bug reports, feature
 - Machine-readable metadata can be derived from metrics, but human judgement prevails, and communication is human-readable, by and for people.
 Templates for responding to extractive contributions can be copy-pasted and automated to encourage contributions that follow the guidelines, without the maintainers needing to custom-respond to every PR.
 - It’s not humans versus machines, it’s clarity v.s. ambiguity.
+
+## Acknowledgements
+- [CMS Technical Review Architecture: AI Code Generation](https://tra.cloud.cms.gov/Application_Development/AD_0010_Application_Introduction.htm)
+- [NASA Fprime AI Policy](https://fprime.jpl.nasa.gov/latest/AI_POLICY/)

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -61,15 +61,29 @@ We don’t accept PRs that:
 - Change core system files such as …
 - Are untested / don’t pass our test suite / don’t pass our linters / don’t follow style guide
 
+#### AI Usage
 - [ ] Generated AI was used in this contribution
 
 If checked, please provide an explanation on how AI was used in the development of this pull request:
 
 - Description: _Include a high level description of Gen AI utilization_
-- Type of assistance: _Code generation, documentation, debugging, testing, refactoring, etc._
+- Type of assistance:
+  - [ ] Code generation
+  - [ ] Documentation
+  - [ ] Debugging
+  - [ ] Testing
+  - [ ] Refactoring
+  - [ ] Other: 
 - Scope of usage: _Which files, functions, or sections were AI-assisted_
-- Tool(s) used: _Name of the AI system(s) employed (e.g., GitHub Copilot, ChatGPT, etc.)_
-- Level of modification: _Whether AI-generated content was used as-is, modified, or used as inspiration_
+- AI System used: 
+  - [ ] ChatGPT
+  - [ ] Claude
+  - [ ] GitHub Copilot
+- Level of modification: 
+  - [ ] As-is
+  - [ ] Modified
+  - [ ] Used as inspiration
+- Prompts used: _Please list or explain prompts that were used to develop this contribution_
 
 ### Example 2: Repositories not accepting AI-generated pull requests
 We don’t accept PRs that:
@@ -95,3 +109,4 @@ Templates for responding to extractive contributions can be copy-pasted and auto
 ## Acknowledgements
 - [CMS Technical Review Architecture: AI Code Generation](https://tra.cloud.cms.gov/Application_Development/AD_0010_Application_Introduction.htm)
 - [NASA Fprime AI Policy](https://fprime.jpl.nasa.gov/latest/AI_POLICY/)
+- [Software Freedom Conservancy: Recommendations When Using LLM-backed Generative AI Systems](https://sfconservancy.org/llm-gen-ai/llm-backed-generative-ai-recommendations.html)

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -24,19 +24,19 @@ The guidelines below are organized around the core tenets we want every develope
 
 ## Guidelines
 
-1. Transparency and Disclosure
+### Transparency and Disclosure
 
 If AI is used in your work, explicitly state where and how it was used in your pull request.
 
 - Acceptable: Using AI to gain understanding of existing code or to brainstorm solution ideas for an issue.
 - Acceptable: Using AI to translate or proofread your comments or PR descriptions, as long as the wording stays as close as possible to what you originally wrote.
 
-2. Human in the Loop
+### Human in the Loop
 Using mentioned above, using AI does not change who's responsible for the code you submit. A person remains accountable for their every contribution and AI does not act on the project's behalf unsupervised.
 
 - Unacceptable: Using external AI tooling *(bots, agents)* to directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub.
 
-3. Responsible Development and Code Quality
+### Responsible Development and Code Quality
 Using AI does not lower the bar and quality of your code contributions.
 
 - Unacceptable: Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -40,8 +40,15 @@ Using mentioned above, using AI does not change who's responsible for the code y
 Using AI does not lower the bar and quality of your code contributions.
 
 - Unacceptable: Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
-- Unacceptable: Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
 - Unacceptable: Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
+
+### Review
+The effort you put into a contribution should meet or exceed the effort it takes to review it. We want to reduce the number of extractive contributions coming in, since this takes valuable time and effort away from doing our work.
+
+- Unacceptable: Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+
+Please refer to [Reducing the Risk of Extractive Contributions](#reducing-the-risk-of-extractive-contributions) section for additional guidance.
+
 
 ## Pull Request Guidelines
 

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -14,7 +14,8 @@ sidenav: true
 sticky_sidenav: true
 ---
 
-## DSACMS Generative AI Policy
+## [Draft] DSACMS Generative AI Policy
+_Last edited: July 8, 2026_
 
 At DSACMS, AI tools *(LLMs, coding assistants)* are welcome as part of contribution workflow, but they don't change who's responsible for the code you submit.
 

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -14,10 +14,34 @@ sidenav: true
 sticky_sidenav: true
 ---
 
-## DSACMS Gen AI Policy
-- Explicitly state where AI was used in PRs
-- Never ship AI code you can’t explain line by line to a developer
-- If the human effort put in a PR, e.g. writing LLM prompts, is less than the effort we would need to put to review it, please don't submit the PR. Think of it this way: we can already write LLM prompts or run automated tools ourselves, and that would be faster and more secure than reviewing external PRs.
+## DSACMS Generative AI Policy
+
+At DSACMS, AI tools *(LLMs, coding assistants)* are welcome as part of contribution workflow, but they don't change who's responsible for the code you submit.
+
+In our repositories, Generative AI usage is outlined in [CONTRIBUTING.md](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.md), which has a dedicated "AI Usage" section covering acceptable and unacceptable uses when contributing directly to repositories.
+
+The guidelines below are organized around the core tenets we want every developer to hold when using Generative AI here at DSACMS.
+
+## Guidelines
+
+1. Transparency and Disclosure
+
+If AI is used in your work, explicitly state where and how it was used in your pull request.
+
+- Acceptable: Using AI to gain understanding of existing code or to brainstorm solution ideas for an issue.
+- Acceptable: Using AI to translate or proofread your comments or PR descriptions, as long as the wording stays as close as possible to what you originally wrote.
+
+2. Human in the Loop
+Using mentioned above, using AI does not change who's responsible for the code you submit. A person remains accountable for their every contribution and AI does not act on the project's behalf unsupervised.
+
+- Unacceptable: Using external AI tooling *(bots, agents)* to directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub.
+
+3. Responsible Development and Code Quality
+Using AI does not lower the bar and quality of your code contributions.
+
+- Unacceptable: Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
+- Unacceptable: Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+- Unacceptable: Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
 
 ## Pull Request Guidelines
 

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -14,7 +14,7 @@ sidenav: true
 sticky_sidenav: true
 ---
 
-## [Draft] DSACMS Generative AI Policy
+## [DRAFT] DSACMS Generative AI Policy
 _Last edited: July 8, 2026_
 
 At DSACMS, AI tools *(LLMs, coding assistants)* are welcome as part of contribution workflow, but they don't change who's responsible for the code you submit.
@@ -79,6 +79,7 @@ If checked, please provide an explanation on how AI was used in the development 
 - AI System used: 
   - [ ] ChatGPT
   - [ ] Claude
+  - [ ] Gemini
   - [ ] GitHub Copilot
 - Level of modification: 
   - [ ] As-is

--- a/content/outbound/gen-ai-policy.md
+++ b/content/outbound/gen-ai-policy.md
@@ -21,12 +21,12 @@ sticky_sidenav: true
 
 ## Pull Request Guidelines
 
-## Example 1: Repositories that allow AI-generated contributions
+### Example 1: Repositories that allow AI-generated contributions
 
 We don’t accept PRs that:
 - Don’t directly address an existing issue
 - Touch more than X files at a time
-- contain more than Y commits
+- Contain more than Y commits
 - Change core system files such as …
 - Are untested / don’t pass our test suite / don’t pass our linters / don’t follow styleguide
 
@@ -34,23 +34,23 @@ We don’t accept PRs that:
 
 If checked, please provide an explanation on how AI was used in the development of this pull request:
 
-## Example 2: Repositories not accepting AI-generated pull requests
+### Example 2: Repositories not accepting AI-generated pull requests
 We don’t accept PRs that:
 - Don’t directly address an existing issue
 - Touch more than X files at a time
-- contain more than Y commits
+- Contain more than Y commits
 - Change core system files such as …
 - Are untested / don’t pass our test suite / don’t pass our linters / don’t follow styleguide
 - Are entirely AI generated
 
 We accept feedback in the form of issues for the following: bug reports, feature requests
 
-**Reducing the risk of Extractive Contributions**
-- Limiting PRs/contributions to existing tickets reduces the risk of ‘roadmap drift’ where contributions take away limited time/energy/attention from the established priorities of the project.
+## Reducing the Risk of Extractive Contributions
+- Limiting PRs/contributions to existing tickets reduces the risk of "roadmap drift", where contributions take away limited time/energy/attention from the established priorities of the project.
 - Limiting files and commits and file surface reduces the ‘splash radius’ and review time needed from a human.
-- Test suite, linters, styleguides ensure that contributions meet our requirements, do not introduce breaking changes, and keep a consistent voice/brand/culture.
+- Test suite, linters, style guides ensure that contributions meet our requirements, do not introduce breaking changes, and keep a consistent voice/brand/culture.
 - These are built to reduce extractive contributions from HUMANS first, and also limits extractive AI contributions as a side-effect.
-- Turns reviews from a high-effort one-off evaluation, into a checklist. Checklists are made for Humans. They create structured spaces for intentional, participatory transition, that reduce cognitive and actual burden and effort.
+- Turns reviews from a high-effort one-off evaluation into a checklist. Checklists are made for Humans. They create structured spaces for intentional, participatory transition that reduce cognitive and actual burden and effort.
 - Machine-readable metadata can be derived from metrics, but human judgement prevails, and communication is human-readable, by and for people.
 Templates for responding to extractive contributions can be copy-pasted and automated to encourage contributions that follow the guidelines, without the maintainers needing to custom-respond to every PR.
 - It’s not humans versus machines, it’s clarity v.s. ambiguity.


### PR DESCRIPTION
## [DRAFT] Outbound: Create new Generative AI Usage policy

## Problem

We would like to create a new guide for Generative AI Usage in Software Development at DSACMS.

## Solution

The new guide for Generative AI Usage in Software Development includes information on:
- Our core values and guidelines around software development and Gen AI usage at DSACMS
- Pull request guidelines for repositories open to AI-generated contributions and those who are not.
- Guide on reducing risk of extractive contributions

## AI Usage
- [x] Generated AI was used in this contribution
- Description: I used LLMs for some inspiration in how to structure our policy and its content. The CMS TRA is framed around core tenets/values so wanted to do something similar and used LLMs to assist me with reorganizing this content.
- Type of assistance:
  - [ ] Code generation
  - [x] Documentation
  - [ ] Debugging
  - [ ] Testing
  - [ ] Refactoring
  - [x] Other: Content
- Scope of usage: Guidelines section in `content/outbound/gen-ai-policy.md`
- AI System used: 
  - [ ] ChatGPT
  - [x] Claude (HHS Claude)
  - [ ] Gemini
  - [ ] GitHub Copilot
- Level of modification: 
  - [ ] As-is
  - [X] Modified
  - [X] Used as inspiration
- Prompts used: 
> My team is making a gen ai policy for the agency and finalizing it. I want to frame the guidelines such that there are tenets that we value (human in the loop, transparency and disclosure, etc.) and want to follow. Please revise the document so that this is explained in this way

## Result

New guide is available to read in the outbound section at: https://dsacms.github.io/ospo-guide/outbound/gen-ai-policy/. Goes hand-in-hand with AI Usage section in CONTRIBUTING.md: https://github.com/DSACMS/repo-scaffolder/pull/394

## Test Plan
`npm run dev` and displays locally!

