### PR TITLE
Resolved Issue: Status Table on the Github page is cut off (#132)

### DIFF
--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -97,13 +97,25 @@ Upstream activity may be below thresholds, but downstream activity indicates act
 
 #### Criteria for Determination
 
-| Status | Description | Open PRs  | Merged/ Closed PRs | Push to repo | Push to forks | Open issues | Closed issues | Criticality Score | Is repo empty/ README only? | 
-| :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
-| Active | This project is under active development and has an active user base | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ | Above $THRESHOLD \_SCORE | Has content |
-| Stable | Upstream activity may be below thresholds, but downstream activity indicates active usage or forks. Usually automated commits by dependabot and no commits by humans | ✅/❌ | ✅/❌ | ✅/❌ | ✅ | ✅/❌ | ✅/❌ | TBD: Consider using the standard deviation of threshold| Has content |
-| Dormant Downstream | Project may be under active development, but does not have an active downstream user or developer base | ✅  | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ Below $THRESHOLD \_SCORE | Has content |
-| Dormant Upstream | Project may have active users, but the core developers or upstream team is inactive. Stars of fork \> Stars of upstream repo | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ Above $THRESHOLD \_SCORE | Has content |
-| Dormant | Project upstream and downstreams are inactive | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ Below $THRESHOLD \_SCORE | Empty OR README-only |
+| Field | Active | Stable | Dormant Downstream | Dormant Upstream | Dormant |
+| :---- | :---- | :---- | :---- | :---- | :---- |
+| Open PRs | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
+| Merged/Closed PRs | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
+| Push to repo | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
+| Push to forks | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Open issues | ✅ | ✅/❌ | ✅ | ✅ | ❌ |
+| Closed issues | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
+| Criticality Score | Above threshold | See note¹ | Below threshold | Above threshold | Below threshold |
+| Repo content | Has content | Has content | Has content | Has content | Empty/README-only |
+
+**Descriptions:**
+- **Active:** This project is under active development and has an active user base
+- **Stable:** Upstream activity may be below thresholds, but downstream activity indicates active usage or forks. Usually automated commits by dependabot and no commits by humans
+- **Dormant Downstream:** Project may be under active development, but does not have an active downstream user or developer base
+- **Dormant Upstream:** Project may have active users, but the core developers or upstream team is inactive. Stars of fork > Stars of upstream repo
+- **Dormant:** Project upstream and downstreams are inactive
+
+¹ *Stable criticality: TBD — consider using standard deviation of the threshold.*
 
 ### Tool: archival-identifier
 

--- a/content/outbound/archiving-repositories.md
+++ b/content/outbound/archiving-repositories.md
@@ -97,25 +97,13 @@ Upstream activity may be below thresholds, but downstream activity indicates act
 
 #### Criteria for Determination
 
-| Field | Active | Stable | Dormant Downstream | Dormant Upstream | Dormant |
-| :---- | :---- | :---- | :---- | :---- | :---- |
-| Open PRs | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
-| Merged/Closed PRs | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
-| Push to repo | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
-| Push to forks | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Open issues | ✅ | ✅/❌ | ✅ | ✅ | ❌ |
-| Closed issues | ✅ | ✅/❌ | ✅ | ❌ | ❌ |
-| Criticality Score | Above threshold | See note¹ | Below threshold | Above threshold | Below threshold |
-| Repo content | Has content | Has content | Has content | Has content | Empty/README-only |
-
-**Descriptions:**
-- **Active:** This project is under active development and has an active user base
-- **Stable:** Upstream activity may be below thresholds, but downstream activity indicates active usage or forks. Usually automated commits by dependabot and no commits by humans
-- **Dormant Downstream:** Project may be under active development, but does not have an active downstream user or developer base
-- **Dormant Upstream:** Project may have active users, but the core developers or upstream team is inactive. Stars of fork > Stars of upstream repo
-- **Dormant:** Project upstream and downstreams are inactive
-
-¹ *Stable criticality: TBD — consider using standard deviation of the threshold.*
+| Status | Open PRs  | Merged/ Closed PRs | Push to repo | Push to forks | Open issues | Closed issues | Criticality Score | Is repo empty/ README only? | 
+| :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
+| **Active**: This project is under active development and has an active user base | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ | Above $THRESHOLD \_SCORE | Has content |
+| **Stable**: Upstream activity may be below thresholds, but downstream activity indicates active usage or forks. Usually automated commits by dependabot and no commits by humans | ✅/❌ | ✅/❌ | ✅/❌ | ✅ | ✅/❌ | ✅/❌ | TBD: Consider using the standard deviation of threshold| Has content |
+| **Dormant Downstream**: Project may be under active development, but does not have an active downstream user or developer base | ✅  | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ Below $THRESHOLD \_SCORE | Has content |
+| **Dormant Upstream**: Project may have active users, but the core developers or upstream team is inactive. Stars of fork \> Stars of upstream repo | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ Above $THRESHOLD \_SCORE | Has content |
+| **Dormant**: Project upstream and downstreams are inactive | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ Below $THRESHOLD \_SCORE | Empty OR README-only |
 
 ### Tool: archival-identifier
 


### PR DESCRIPTION
## outbound/archiving-repositories: Fix clipped status table on GitHub page

## Problem

The repo activity status table in `content/outbound/archiving-repositories.md`
was too wide to render properly on the GitHub page — it was clipped with no
horizontal scrolling element, making the "Criticality Score" and "Is repo
empty/README only?" columns unreadable (#132).

## Solution

Restructured the table so that the status name and the description share one columns.

## Result

The status table now displays fully on the GitHub page without clipping.

<img width="1157" height="801" alt="image" src="https://github.com/user-attachments/assets/04db7978-f78e-4611-af0f-a877277c65cb" />

## Test Plan

Render the updated markdown locally (npm run clean, npm run build, npm run start) to confirm the table displays fully
within the page width. 

## AI Usage 

No AI was used in this iteration, development was based on Remy's feedback.